### PR TITLE
Add multi-file sync and auto-push support with semantic paths

### DIFF
--- a/KtsuTools.CodeGen/CodeGenService.cs
+++ b/KtsuTools.CodeGen/CodeGenService.cs
@@ -7,6 +7,7 @@ namespace KtsuTools.CodeGen;
 using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Text;
+using ktsu.Semantics.Paths;
 using Spectre.Console;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
@@ -275,14 +276,18 @@ public class CodeGenService
 	/// <summary>
 	/// Generates code from a YAML AST definition file.
 	/// </summary>
+	/// <param name="inputFile">Absolute path to the YAML AST input file.</param>
+	/// <param name="language">Target language identifier (e.g. "csharp", "python").</param>
+	/// <param name="outputFile">Optional absolute path to write generated code to. If null, writes to console.</param>
+	/// <param name="ct">Cancellation token.</param>
+	/// <returns>Exit code (0 for success).</returns>
 #pragma warning disable CA1822 // Mark members as static - instance method required for DI injection
-	public async Task<int> GenerateAsync(string inputFile, string language, string? outputFile = null, CancellationToken ct = default)
+	public async Task<int> GenerateAsync(AbsoluteFilePath inputFile, string language, AbsoluteFilePath? outputFile = null, CancellationToken ct = default)
 #pragma warning restore CA1822
 	{
-		Ensure.NotNull(inputFile);
 		Ensure.NotNull(language);
 
-		string fullPath = Path.GetFullPath(inputFile);
+		string fullPath = inputFile.ToString();
 
 		if (!File.Exists(fullPath))
 		{
@@ -316,7 +321,7 @@ public class CodeGenService
 		// Output
 		if (outputFile is not null)
 		{
-			string outputPath = Path.GetFullPath(outputFile);
+			string outputPath = outputFile.ToString();
 			await File.WriteAllTextAsync(outputPath, generatedCode, ct).ConfigureAwait(false);
 			AnsiConsole.MarkupLine($"[green]Generated code written to: {outputPath.EscapeMarkup()}[/]");
 		}

--- a/KtsuTools.CodeGen/KtsuTools.CodeGen.csproj
+++ b/KtsuTools.CodeGen/KtsuTools.CodeGen.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="YamlDotNet" />
+    <PackageReference Include="ktsu.Semantics.Paths" />
   </ItemGroup>
 
   <ItemGroup>

--- a/KtsuTools.FileExplorer/FileExplorerService.cs
+++ b/KtsuTools.FileExplorer/FileExplorerService.cs
@@ -4,6 +4,7 @@
 
 namespace KtsuTools.FileExplorer;
 
+using ktsu.Semantics.Paths;
 using Spectre.Console;
 
 /// <summary>
@@ -52,11 +53,16 @@ public class FileExplorerService
 	/// <summary>
 	/// Runs the interactive file explorer TUI.
 	/// </summary>
+	/// <param name="startPath">Absolute starting directory.</param>
+	/// <param name="showHidden">Whether to show hidden entries.</param>
+	/// <param name="showSizes">Whether to show file sizes.</param>
+	/// <param name="ct">Cancellation token.</param>
+	/// <returns>Exit code (0 for success).</returns>
 #pragma warning disable CA1822 // Mark members as static - instance method required for DI injection
-	public async Task<int> RunAsync(string startPath = ".", bool showHidden = false, bool showSizes = true, CancellationToken ct = default)
+	public async Task<int> RunAsync(AbsoluteDirectoryPath startPath, bool showHidden = false, bool showSizes = true, CancellationToken ct = default)
 #pragma warning restore CA1822
 	{
-		string currentPath = Path.GetFullPath(startPath);
+		string currentPath = startPath.ToString();
 
 		if (!Directory.Exists(currentPath))
 		{

--- a/KtsuTools.FileExplorer/KtsuTools.FileExplorer.csproj
+++ b/KtsuTools.FileExplorer/KtsuTools.FileExplorer.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Spectre.Console" />
+    <PackageReference Include="ktsu.Semantics.Paths" />
   </ItemGroup>
 
   <ItemGroup>

--- a/KtsuTools.Merge/KtsuTools.Merge.csproj
+++ b/KtsuTools.Merge/KtsuTools.Merge.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Spectre.Console" />
     <PackageReference Include="DiffPlex" />
+    <PackageReference Include="ktsu.Semantics.Paths" />
   </ItemGroup>
 
   <ItemGroup>

--- a/KtsuTools.Merge/MergeService.cs
+++ b/KtsuTools.Merge/MergeService.cs
@@ -10,6 +10,7 @@ using System.Text;
 using DiffPlex;
 using DiffPlex.DiffBuilder;
 using DiffPlex.DiffBuilder.Model;
+using ktsu.Semantics.Paths;
 using Spectre.Console;
 
 /// <summary>
@@ -48,14 +49,17 @@ public class MergeService
 	/// <summary>
 	/// Runs the merge operation for files matching a pattern in a directory.
 	/// </summary>
+	/// <param name="directory">Absolute root directory under which to search.</param>
+	/// <param name="filename">Glob pattern to match against filenames.</param>
+	/// <param name="ct">Cancellation token.</param>
+	/// <returns>Exit code (0 for success).</returns>
 #pragma warning disable CA1822 // Mark members as static - instance method required for DI injection
-	public async Task<int> RunMergeAsync(string directory, string filename, CancellationToken ct = default)
+	public async Task<int> RunMergeAsync(AbsoluteDirectoryPath directory, string filename, CancellationToken ct = default)
 #pragma warning restore CA1822
 	{
-		Ensure.NotNull(directory);
 		Ensure.NotNull(filename);
 
-		string fullPath = Path.GetFullPath(directory);
+		string fullPath = directory.ToString();
 
 		if (!Directory.Exists(fullPath))
 		{

--- a/KtsuTools.Sync/SyncService.cs
+++ b/KtsuTools.Sync/SyncService.cs
@@ -42,7 +42,18 @@ public class SyncService(IProcessService processService)
 	/// <param name="filename">The filename pattern to scan for.</param>
 	/// <param name="ct">Cancellation token.</param>
 	/// <returns>Exit code (0 for success).</returns>
-	public async Task<int> RunAsync(string path, string filename, CancellationToken ct = default)
+	public Task<int> RunAsync(string path, string filename, CancellationToken ct = default) =>
+		RunAsync(path, [filename], autoPush: false, ct);
+
+	/// <summary>
+	/// Runs the sync operation for the specified path and one or more filename patterns.
+	/// </summary>
+	/// <param name="path">The root path to scan recursively.</param>
+	/// <param name="filenames">One or more filename patterns to scan for.</param>
+	/// <param name="autoPush">When true, repos whose unpushed commits are all authored by KtsuTools are pushed without prompting.</param>
+	/// <param name="ct">Cancellation token.</param>
+	/// <returns>Exit code (0 for success).</returns>
+	public async Task<int> RunAsync(string path, IReadOnlyList<string> filenames, bool autoPush, CancellationToken ct = default)
 	{
 		ct.ThrowIfCancellationRequested();
 
@@ -52,13 +63,34 @@ public class SyncService(IProcessService processService)
 			return 1;
 		}
 
-		AnsiConsole.MarkupLine($"[bold]Scanning for:[/] {filename.EscapeMarkup()}");
+		List<string> patterns = [.. filenames
+			.Select(f => f?.Trim() ?? string.Empty)
+			.Where(f => !string.IsNullOrEmpty(f))
+			.Distinct(StringComparer.Ordinal)];
+
+		if (patterns.Count == 0)
+		{
+			AnsiConsole.MarkupLine("[red]No filename patterns provided.[/]");
+			return 1;
+		}
+
+		AnsiConsole.MarkupLine($"[bold]Scanning for:[/] {string.Join(", ", patterns).EscapeMarkup()}");
 		AnsiConsole.MarkupLine($"[bold]In:[/] {path.EscapeMarkup()}");
 		AnsiConsole.WriteLine();
 
-		Collection<string> fileEnumeration = Directory.EnumerateFiles(path, filename, SearchOption.AllDirectories)
-			.Where(f => !IsRepoNested(AbsoluteFilePath.Create<AbsoluteFilePath>(f).AbsoluteDirectoryPath))
-			.ToCollection();
+		HashSet<string> seen = new(StringComparer.Ordinal);
+		Collection<string> fileEnumeration = [];
+		foreach (string pattern in patterns)
+		{
+			foreach (string file in Directory.EnumerateFiles(path, pattern, SearchOption.AllDirectories)
+				.Where(f => !IsRepoNested(AbsoluteFilePath.Create<AbsoluteFilePath>(f).AbsoluteDirectoryPath)))
+			{
+				if (seen.Add(file))
+				{
+					fileEnumeration.Add(file);
+				}
+			}
+		}
 
 		IEnumerable<string> uniqueFilenames = fileEnumeration.Select(Path.GetFileName).Distinct()!;
 		AnsiConsole.MarkupLine($"[bold]Found matches:[/] {string.Join(", ", uniqueFilenames).EscapeMarkup()}");
@@ -76,7 +108,7 @@ public class SyncService(IProcessService processService)
 
 		await CommitChangedFilesAsync(commitDirectories, expandedFilesToSync, path).ConfigureAwait(false);
 
-		await PushToRemoteAsync(commitDirectories, path, ct).ConfigureAwait(false);
+		await PushToRemoteAsync(commitDirectories, path, autoPush, ct).ConfigureAwait(false);
 
 		return 0;
 	}
@@ -344,24 +376,37 @@ public class SyncService(IProcessService processService)
 		}
 	}
 
-	private async Task PushToRemoteAsync(HashSet<string> commitDirectories, string path, CancellationToken ct)
+	private async Task PushToRemoteAsync(HashSet<string> commitDirectories, string path, bool autoPush, CancellationToken ct)
 	{
 		Collection<string> pushDirectories = FindPushableDirectories(commitDirectories, path);
 
-		if (pushDirectories.Count > 0)
+		if (pushDirectories.Count == 0)
 		{
-			AnsiConsole.WriteLine();
-			bool confirmed = await AnsiConsole.ConfirmAsync("Push changes to remote?", defaultValue: false, cancellationToken: ct).ConfigureAwait(false);
+			return;
+		}
 
-			if (confirmed)
-			{
-				AnsiConsole.WriteLine();
-				foreach (string dir in pushDirectories)
-				{
-					ct.ThrowIfCancellationRequested();
-					await PushDirectoryAsync(dir, ct).ConfigureAwait(false);
-				}
-			}
+		AnsiConsole.WriteLine();
+		bool confirmed;
+		if (autoPush)
+		{
+			AnsiConsole.MarkupLine("[dim]--auto-push enabled; all unpushed commits are by KtsuTools, pushing without prompting.[/]");
+			confirmed = true;
+		}
+		else
+		{
+			confirmed = await AnsiConsole.ConfirmAsync("Push changes to remote?", defaultValue: false, cancellationToken: ct).ConfigureAwait(false);
+		}
+
+		if (!confirmed)
+		{
+			return;
+		}
+
+		AnsiConsole.WriteLine();
+		foreach (string dir in pushDirectories)
+		{
+			ct.ThrowIfCancellationRequested();
+			await PushDirectoryAsync(dir, ct).ConfigureAwait(false);
 		}
 	}
 
@@ -403,8 +448,10 @@ public class SyncService(IProcessService processService)
 		if (pull.ExitCode != 0)
 		{
 			string pullMessage = pull.Errors.Count > 0 ? string.Join('\n', pull.Errors) : string.Join('\n', pull.Output);
-			AnsiConsole.MarkupLine($"[yellow]Warning during pull:[/] {pullMessage.EscapeMarkup()}");
-			AnsiConsole.MarkupLine("[dim]Continuing with push...[/]");
+			AnsiConsole.MarkupLine($"[red]Pull failed for:[/] {repoRoot.EscapeMarkup()}");
+			AnsiConsole.MarkupLine($"[red]{pullMessage.EscapeMarkup()}[/]");
+			AnsiConsole.MarkupLine("[yellow]Skipping push to avoid non-fast-forward; resolve conflicts manually.[/]");
+			return;
 		}
 
 		ProcessResult push = await processService.RunAsync("git", "push", repoRoot, ct).ConfigureAwait(false);

--- a/KtsuTools.Test/MergeServiceTests.cs
+++ b/KtsuTools.Test/MergeServiceTests.cs
@@ -5,6 +5,7 @@
 namespace KtsuTools.Test;
 
 using System.IO;
+using ktsu.Semantics.Paths;
 using KtsuTools.Merge;
 
 [TestClass]
@@ -15,7 +16,8 @@ public class MergeServiceTests
 	{
 		MergeService service = new();
 		string missing = Path.Combine(Path.GetTempPath(), $"ktsu_missing_{Guid.NewGuid():N}");
-		int result = await service.RunMergeAsync(missing, "*.txt").ConfigureAwait(false);
+		AbsoluteDirectoryPath missingPath = AbsoluteDirectoryPath.Create<AbsoluteDirectoryPath>(missing);
+		int result = await service.RunMergeAsync(missingPath, "*.txt").ConfigureAwait(false);
 		Assert.AreEqual(1, result);
 	}
 
@@ -28,7 +30,8 @@ public class MergeServiceTests
 		{
 			await File.WriteAllTextAsync(Path.Combine(root, "only.txt"), "hello").ConfigureAwait(false);
 			MergeService service = new();
-			int result = await service.RunMergeAsync(root, "only.txt").ConfigureAwait(false);
+			AbsoluteDirectoryPath rootPath = AbsoluteDirectoryPath.Create<AbsoluteDirectoryPath>(root);
+			int result = await service.RunMergeAsync(rootPath, "only.txt").ConfigureAwait(false);
 			Assert.AreEqual(0, result, "Expected success exit code when there's nothing to merge.");
 		}
 		finally
@@ -50,7 +53,8 @@ public class MergeServiceTests
 			await File.WriteAllTextAsync(Path.Combine(subA, "shared.txt"), "same content").ConfigureAwait(false);
 			await File.WriteAllTextAsync(Path.Combine(subB, "shared.txt"), "same content").ConfigureAwait(false);
 			MergeService service = new();
-			int result = await service.RunMergeAsync(root, "shared.txt").ConfigureAwait(false);
+			AbsoluteDirectoryPath rootPath = AbsoluteDirectoryPath.Create<AbsoluteDirectoryPath>(root);
+			int result = await service.RunMergeAsync(rootPath, "shared.txt").ConfigureAwait(false);
 			Assert.AreEqual(0, result, "Identical files should hash into one group and exit cleanly.");
 		}
 		finally

--- a/KtsuTools/Commands/CodeGenCommand.cs
+++ b/KtsuTools/Commands/CodeGenCommand.cs
@@ -5,6 +5,8 @@
 namespace KtsuTools.Commands;
 
 using System.ComponentModel;
+using System.IO;
+using ktsu.Semantics.Paths;
 using KtsuTools.CodeGen;
 using KtsuTools.Core.UI;
 using Spectre.Console.Cli;
@@ -33,10 +35,14 @@ public sealed class CodeGenCommand(CodeGenService codeGenService) : AsyncCommand
 	{
 		Ensure.NotNull(settings);
 		using CtrlCScope scope = new();
+		AbsoluteFilePath inputFile = AbsoluteFilePath.Create<AbsoluteFilePath>(Path.GetFullPath(settings.InputFile));
+		AbsoluteFilePath? outputFile = settings.OutputFile is null
+			? null
+			: AbsoluteFilePath.Create<AbsoluteFilePath>(Path.GetFullPath(settings.OutputFile));
 		return await codeGenService.GenerateAsync(
-			settings.InputFile,
+			inputFile,
 			settings.Language,
-			settings.OutputFile,
+			outputFile,
 			scope.Token).ConfigureAwait(false);
 	}
 }

--- a/KtsuTools/Commands/ExplorerCommand.cs
+++ b/KtsuTools/Commands/ExplorerCommand.cs
@@ -5,6 +5,8 @@
 namespace KtsuTools.Commands;
 
 using System.ComponentModel;
+using System.IO;
+using ktsu.Semantics.Paths;
 using KtsuTools.Core.UI;
 using KtsuTools.FileExplorer;
 using Spectre.Console.Cli;
@@ -35,8 +37,9 @@ public sealed class ExplorerCommand(FileExplorerService fileExplorerService) : A
 	{
 		Ensure.NotNull(settings);
 		using CtrlCScope scope = new();
+		AbsoluteDirectoryPath startPath = AbsoluteDirectoryPath.Create<AbsoluteDirectoryPath>(Path.GetFullPath(settings.StartPath));
 		return await fileExplorerService.RunAsync(
-			settings.StartPath,
+			startPath,
 			settings.ShowHidden,
 			settings.ShowSizes,
 			scope.Token).ConfigureAwait(false);

--- a/KtsuTools/Commands/MergeCommand.cs
+++ b/KtsuTools/Commands/MergeCommand.cs
@@ -5,6 +5,8 @@
 namespace KtsuTools.Commands;
 
 using System.ComponentModel;
+using System.IO;
+using ktsu.Semantics.Paths;
 using KtsuTools.Core.UI;
 using KtsuTools.Merge;
 using Spectre.Console.Cli;
@@ -28,8 +30,9 @@ public sealed class MergeCommand(MergeService mergeService) : AsyncCommand<Merge
 	{
 		Ensure.NotNull(settings);
 		using CtrlCScope scope = new();
+		AbsoluteDirectoryPath directory = AbsoluteDirectoryPath.Create<AbsoluteDirectoryPath>(Path.GetFullPath(settings.Directory));
 		return await mergeService.RunMergeAsync(
-			settings.Directory,
+			directory,
 			settings.Filename,
 			scope.Token).ConfigureAwait(false);
 	}

--- a/KtsuTools/Commands/SyncCommand.cs
+++ b/KtsuTools/Commands/SyncCommand.cs
@@ -4,7 +4,10 @@
 
 namespace KtsuTools.Commands;
 
+using System;
+using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 using System.Threading.Tasks;
 using KtsuTools.Core.UI;
 using KtsuTools.Sync;
@@ -31,11 +34,18 @@ public sealed class SyncCommand(SyncService syncService) : AsyncCommand<SyncComm
 		public string Path { get; init; } = string.Empty;
 
 		/// <summary>
-		/// Gets the filename to scan for.
+		/// Gets the filename patterns to scan for. May be specified multiple times or comma-separated.
 		/// </summary>
 		[CommandOption("--filename <FILENAME>")]
-		[Description("The filename to scan for")]
-		public string Filename { get; init; } = string.Empty;
+		[Description("Filename pattern to scan for. Repeat the flag or pass a comma-separated list to sync several files in one run.")]
+		public string[] Filename { get; init; } = [];
+
+		/// <summary>
+		/// Gets a value indicating whether to push without prompting when all unpushed commits were authored by KtsuTools.
+		/// </summary>
+		[CommandOption("--auto-push")]
+		[Description("Push without prompting when every unpushed commit on a repo was authored by KtsuTools.")]
+		public bool AutoPush { get; init; }
 	}
 
 	/// <inheritdoc/>
@@ -47,11 +57,21 @@ public sealed class SyncCommand(SyncService syncService) : AsyncCommand<SyncComm
 			? await AnsiConsole.AskAsync<string>("[bold]Root path to scan:[/]").ConfigureAwait(false)
 			: settings.Path;
 
-		string filename = string.IsNullOrWhiteSpace(settings.Filename)
-			? await AnsiConsole.AskAsync<string>("[bold]Filename pattern to scan for:[/]").ConfigureAwait(false)
-			: settings.Filename;
+		List<string> filenames = ExpandFilenames(settings.Filename);
+		if (filenames.Count == 0)
+		{
+			string entered = await AnsiConsole.AskAsync<string>("[bold]Filename pattern(s) to scan for (comma-separated):[/]").ConfigureAwait(false);
+			filenames = ExpandFilenames([entered]);
+		}
 
 		using CtrlCScope scope = new();
-		return await syncService.RunAsync(path, filename, scope.Token).ConfigureAwait(false);
+		return await syncService.RunAsync(path, filenames, settings.AutoPush, scope.Token).ConfigureAwait(false);
 	}
+
+	private static List<string> ExpandFilenames(IEnumerable<string> raw) =>
+		[.. raw
+			.Where(v => v is not null)
+			.SelectMany(v => v.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+			.Where(v => !string.IsNullOrWhiteSpace(v))
+			.Distinct(StringComparer.Ordinal)];
 }


### PR DESCRIPTION
## Summary
This PR enhances the sync functionality to support multiple filename patterns in a single run and adds an optional auto-push feature. Additionally, it introduces semantic path types (`AbsoluteFilePath` and `AbsoluteDirectoryPath`) across multiple services for improved type safety.

## Key Changes

### Sync Service Enhancements
- **Multi-file support**: Changed `RunAsync` to accept `IReadOnlyList<string>` filenames instead of a single filename, allowing users to sync multiple files in one operation
- **Overload for backward compatibility**: Added a single-filename overload that delegates to the multi-file version
- **Auto-push feature**: Added `autoPush` parameter to automatically push changes when all unpushed commits are authored by KtsuTools, without prompting
- **Improved file enumeration**: Implemented deduplication logic using a `HashSet` to handle overlapping patterns across multiple filename inputs
- **Better error handling**: Enhanced pull failure handling to skip push operations and provide clearer error messages instead of continuing with potentially unsafe operations

### Command Interface Updates
- **Sync command**: Updated `--filename` flag to accept multiple values (repeatable or comma-separated list)
- **Auto-push flag**: Added `--auto-push` command option to enable automatic pushing
- **Filename expansion**: Implemented `ExpandFilenames` helper to parse comma-separated and repeated filename arguments

### Semantic Path Type Integration
- **CodeGenService**: Changed `GenerateAsync` parameters from `string` to `AbsoluteFilePath` and `AbsoluteFilePath?`
- **FileExplorerService**: Changed `RunAsync` parameter from `string` to `AbsoluteDirectoryPath`
- **MergeService**: Changed `RunMergeAsync` parameter from `string` to `AbsoluteDirectoryPath`
- **Command handlers**: Updated all command classes to convert user input to semantic path types before calling services
- **Dependencies**: Added `ktsu.Semantics.Paths` package reference to affected projects

## Notable Implementation Details
- File deduplication across multiple patterns prevents duplicate processing when patterns overlap
- Pull failures now halt the push operation with a clear message directing users to resolve conflicts manually
- The auto-push feature respects the existing commit author validation logic
- Semantic path types provide compile-time safety and eliminate the need for manual `Path.GetFullPath()` calls in service methods

https://claude.ai/code/session_014AXftF6Mm9h24JSzaHi9H4