### PR TITLE
Refactor monitoring loops to use IntervalAction utility

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -37,6 +37,7 @@
     <!-- ktsu packages -->
     <PackageVersion Include="ktsu.AppDataStorage" Version="1.15.6" />
     <PackageVersion Include="ktsu.Extensions" Version="1.5.6" />
+    <PackageVersion Include="ktsu.IntervalAction" Version="1.3.10" />
     <PackageVersion Include="ktsu.RunCommand" Version="1.3.5" />
     <PackageVersion Include="ktsu.Semantics" Version="1.0.18" />
     <PackageVersion Include="ktsu.Frontmatter" Version="1.1.0" />

--- a/KtsuTools.BuildMonitor/BuildMonitorService.cs
+++ b/KtsuTools.BuildMonitor/BuildMonitorService.cs
@@ -58,7 +58,7 @@ public class BuildMonitorService(IGitHubService gitHubService)
 
 				Tick();
 
-				using IntervalAction ticker = IntervalAction.Start(new IntervalActionOptions
+				IntervalAction ticker = IntervalAction.Start(new IntervalActionOptions
 				{
 					ActionInterval = interval,
 					PollingInterval = interval,

--- a/KtsuTools.BuildMonitor/BuildMonitorService.cs
+++ b/KtsuTools.BuildMonitor/BuildMonitorService.cs
@@ -10,6 +10,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Humanizer;
+using ktsu.IntervalAction;
 using KtsuTools.Core.Services.GitHub;
 using Spectre.Console;
 using Spectre.Console.Rendering;
@@ -37,31 +38,42 @@ public class BuildMonitorService(IGitHubService gitHubService)
 			.AutoClear(true)
 			.StartAsync(async ctx =>
 			{
-				while (!ct.IsCancellationRequested)
+				TimeSpan interval = TimeSpan.FromSeconds(refreshIntervalSeconds);
+
+				void Tick()
 				{
 					try
 					{
-						Table table = await BuildDashboardTableAsync(owner, ct).ConfigureAwait(false);
+						Table table = BuildDashboardTableAsync(owner, ct).GetAwaiter().GetResult();
 						ctx.UpdateTarget(table);
 					}
 					catch (OperationCanceledException)
 					{
-						break;
 					}
 					catch (HttpRequestException ex)
 					{
 						ctx.UpdateTarget(new Markup($"[red]API Error: {ex.Message.EscapeMarkup()}[/]"));
 					}
-
-					try
-					{
-						await Task.Delay(TimeSpan.FromSeconds(refreshIntervalSeconds), ct).ConfigureAwait(false);
-					}
-					catch (OperationCanceledException)
-					{
-						break;
-					}
 				}
+
+				Tick();
+
+				using IntervalAction ticker = IntervalAction.Start(new IntervalActionOptions
+				{
+					ActionInterval = interval,
+					PollingInterval = interval,
+					Action = Tick,
+				});
+
+				try
+				{
+					await Task.Delay(Timeout.InfiniteTimeSpan, ct).ConfigureAwait(false);
+				}
+				catch (OperationCanceledException)
+				{
+				}
+
+				ticker.Stop();
 			}).ConfigureAwait(false);
 	}
 

--- a/KtsuTools.BuildMonitor/KtsuTools.BuildMonitor.csproj
+++ b/KtsuTools.BuildMonitor/KtsuTools.BuildMonitor.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Spectre.Console" />
     <PackageReference Include="Humanizer.Core" ExcludeAssets="analyzers" />
     <PackageReference Include="ktsu.TextFilter" />
+    <PackageReference Include="ktsu.IntervalAction" />
   </ItemGroup>
 
   <ItemGroup>

--- a/KtsuTools.CodeGen/CodeGenService.cs
+++ b/KtsuTools.CodeGen/CodeGenService.cs
@@ -285,6 +285,7 @@ public class CodeGenService
 	public async Task<int> GenerateAsync(AbsoluteFilePath inputFile, string language, AbsoluteFilePath? outputFile = null, CancellationToken ct = default)
 #pragma warning restore CA1822
 	{
+		Ensure.NotNull(inputFile);
 		Ensure.NotNull(language);
 
 		string fullPath = inputFile.ToString();

--- a/KtsuTools.FileExplorer/FileExplorerService.cs
+++ b/KtsuTools.FileExplorer/FileExplorerService.cs
@@ -62,6 +62,8 @@ public class FileExplorerService
 	public async Task<int> RunAsync(AbsoluteDirectoryPath startPath, bool showHidden = false, bool showSizes = true, CancellationToken ct = default)
 #pragma warning restore CA1822
 	{
+		Ensure.NotNull(startPath);
+
 		string currentPath = startPath.ToString();
 
 		if (!Directory.Exists(currentPath))

--- a/KtsuTools.Machine/KtsuTools.Machine.csproj
+++ b/KtsuTools.Machine/KtsuTools.Machine.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Spectre.Console" />
     <PackageReference Include="LibreHardwareMonitorLib" />
     <PackageReference Include="Humanizer.Core" ExcludeAssets="analyzers" />
+    <PackageReference Include="ktsu.IntervalAction" />
   </ItemGroup>
 
   <ItemGroup>

--- a/KtsuTools.Machine/MachineMonitorService.cs
+++ b/KtsuTools.Machine/MachineMonitorService.cs
@@ -60,7 +60,7 @@ public class MachineMonitorService
 
 					Tick();
 
-					using IntervalAction ticker = IntervalAction.Start(new IntervalActionOptions
+					IntervalAction ticker = IntervalAction.Start(new IntervalActionOptions
 					{
 						ActionInterval = interval,
 						PollingInterval = interval,

--- a/KtsuTools.Machine/MachineMonitorService.cs
+++ b/KtsuTools.Machine/MachineMonitorService.cs
@@ -10,6 +10,7 @@ using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using ktsu.IntervalAction;
 using LibreHardwareMonitor.Hardware;
 using Spectre.Console;
 using Spectre.Console.Rendering;
@@ -48,31 +49,33 @@ public class MachineMonitorService
 			AnsiConsole.WriteLine();
 
 			IRenderable initial = new Text("Loading hardware sensors...");
+			Computer computerCapture = computer;
 			await AnsiConsole.Live(initial)
 				.AutoClear(true)
 				.StartAsync(async ctx =>
 				{
-					while (!ct.IsCancellationRequested)
-					{
-						try
-						{
-							Table dashboard = BuildDashboard(computer);
-							ctx.UpdateTarget(dashboard);
-						}
-						catch (OperationCanceledException)
-						{
-							break;
-						}
+					TimeSpan interval = TimeSpan.FromMilliseconds(refreshIntervalMs);
 
-						try
-						{
-							await Task.Delay(refreshIntervalMs, ct).ConfigureAwait(false);
-						}
-						catch (OperationCanceledException)
-						{
-							break;
-						}
+					void Tick() => ctx.UpdateTarget(BuildDashboard(computerCapture));
+
+					Tick();
+
+					using IntervalAction ticker = IntervalAction.Start(new IntervalActionOptions
+					{
+						ActionInterval = interval,
+						PollingInterval = interval,
+						Action = Tick,
+					});
+
+					try
+					{
+						await Task.Delay(Timeout.InfiniteTimeSpan, ct).ConfigureAwait(false);
 					}
+					catch (OperationCanceledException)
+					{
+					}
+
+					ticker.Stop();
 				}).ConfigureAwait(false);
 		}
 		finally

--- a/KtsuTools.MemFrag/KtsuTools.MemFrag.csproj
+++ b/KtsuTools.MemFrag/KtsuTools.MemFrag.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Spectre.Console" />
+    <PackageReference Include="ktsu.IntervalAction" />
   </ItemGroup>
 
   <ItemGroup>

--- a/KtsuTools.MemFrag/MemFragService.cs
+++ b/KtsuTools.MemFrag/MemFragService.cs
@@ -9,6 +9,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
+using ktsu.IntervalAction;
 using Spectre.Console;
 using Spectre.Console.Rendering;
 
@@ -78,33 +79,46 @@ public class MemFragService
 			AnsiConsole.WriteLine();
 
 			IRenderable initial = new Text("Loading...");
+			Process processCapture = process;
 			await AnsiConsole.Live(initial)
 				.AutoClear(true)
 				.StartAsync(async ctx =>
 				{
-					while (!ct.IsCancellationRequested)
+					using CancellationTokenSource exitedCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+					TimeSpan interval = TimeSpan.FromMilliseconds(refreshIntervalMs);
+
+					void Tick()
 					{
 						try
 						{
-							process.Refresh();
-							Table table = BuildMemoryTable(process);
-							ctx.UpdateTarget(table);
+							processCapture.Refresh();
+							ctx.UpdateTarget(BuildMemoryTable(processCapture));
 						}
 						catch (InvalidOperationException)
 						{
 							ctx.UpdateTarget(new Markup("[red]Process has exited.[/]"));
-							break;
-						}
-
-						try
-						{
-							await Task.Delay(refreshIntervalMs, ct).ConfigureAwait(false);
-						}
-						catch (OperationCanceledException)
-						{
-							break;
+							exitedCts.Cancel();
 						}
 					}
+
+					Tick();
+
+					using IntervalAction ticker = IntervalAction.Start(new IntervalActionOptions
+					{
+						ActionInterval = interval,
+						PollingInterval = interval,
+						Action = Tick,
+					});
+
+					try
+					{
+						await Task.Delay(Timeout.InfiniteTimeSpan, exitedCts.Token).ConfigureAwait(false);
+					}
+					catch (OperationCanceledException)
+					{
+					}
+
+					ticker.Stop();
 				}).ConfigureAwait(false);
 		}
 

--- a/KtsuTools.MemFrag/MemFragService.cs
+++ b/KtsuTools.MemFrag/MemFragService.cs
@@ -103,7 +103,7 @@ public class MemFragService
 
 					Tick();
 
-					using IntervalAction ticker = IntervalAction.Start(new IntervalActionOptions
+					IntervalAction ticker = IntervalAction.Start(new IntervalActionOptions
 					{
 						ActionInterval = interval,
 						PollingInterval = interval,

--- a/KtsuTools.Merge/MergeService.cs
+++ b/KtsuTools.Merge/MergeService.cs
@@ -57,6 +57,7 @@ public class MergeService
 	public async Task<int> RunMergeAsync(AbsoluteDirectoryPath directory, string filename, CancellationToken ct = default)
 #pragma warning restore CA1822
 	{
+		Ensure.NotNull(directory);
 		Ensure.NotNull(filename);
 
 		string fullPath = directory.ToString();

--- a/KtsuTools/Commands/SyncCommand.cs
+++ b/KtsuTools/Commands/SyncCommand.cs
@@ -38,7 +38,9 @@ public sealed class SyncCommand(SyncService syncService) : AsyncCommand<SyncComm
 		/// </summary>
 		[CommandOption("--filename <FILENAME>")]
 		[Description("Filename pattern to scan for. Repeat the flag or pass a comma-separated list to sync several files in one run.")]
+#pragma warning disable CA1819 // Properties should not return arrays - Spectre.Console.Cli binds multi-value options via T[] only.
 		public string[] Filename { get; init; } = [];
+#pragma warning restore CA1819
 
 		/// <summary>
 		/// Gets a value indicating whether to push without prompting when all unpushed commits were authored by KtsuTools.


### PR DESCRIPTION
## Summary
Refactored three monitoring services to use the `ktsu.IntervalAction` library instead of manual while-loop implementations with `Task.Delay`. This improves code maintainability and provides a more robust pattern for periodic task execution.

## Key Changes
- **MachineMonitorService**: Replaced while-loop with `IntervalAction` for hardware sensor dashboard updates
- **MemFragService**: Replaced while-loop with `IntervalAction` for process memory monitoring, added linked cancellation token to handle process exit events
- **BuildMonitorService**: Replaced while-loop with `IntervalAction` for build status monitoring, changed async call to synchronous execution within the tick action
- **Dependencies**: Added `ktsu.IntervalAction` package (v1.3.10) to three project files

## Implementation Details
- Each service now defines a `Tick()` action that performs the monitoring work
- `IntervalAction.Start()` is called with `ActionInterval` and `PollingInterval` set to the refresh interval
- The main task now waits indefinitely on `Task.Delay(Timeout.InfiniteTimeSpan, ct)` instead of looping with delays
- Cancellation is handled by catching `OperationCanceledException` and calling `ticker.Stop()`
- In MemFragService, a linked cancellation token source is used to handle both external cancellation and process exit events
- Local variable captures (`computerCapture`, `processCapture`) are used to ensure closure semantics work correctly with the tick action

https://claude.ai/code/session_015nyEtaBBNsbsoQHsboGddE