### PR TITLE
Expand ktsu.Semantics.Paths usage across services (#14)

### DIFF
--- a/KtsuTools.Image/ImageService.cs
+++ b/KtsuTools.Image/ImageService.cs
@@ -7,6 +7,8 @@ namespace KtsuTools.Image;
 using System.Globalization;
 using System.IO;
 
+using ktsu.Semantics.Paths;
+
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Formats.Png;
 using SixLabors.ImageSharp.PixelFormats;
@@ -31,17 +33,22 @@ public static class ImageService
 	/// <param name="padding">Padding in pixels added around the content. Must be less than size / 2.</param>
 	/// <param name="ct">Cancellation token.</param>
 	/// <returns>The number of successfully processed files.</returns>
-	public static async Task<int> ProcessAsync(string inputPath, string outputPath, string color = "#FFFFFF", int size = 128, int padding = 0, CancellationToken ct = default)
+	public static async Task<int> ProcessAsync(AbsoluteDirectoryPath inputPath, AbsoluteDirectoryPath outputPath, string color = "#FFFFFF", int size = 128, int padding = 0, CancellationToken ct = default)
 	{
+		Ensure.NotNull(inputPath);
+		Ensure.NotNull(outputPath);
 		Ensure.NotNull(color);
 
-		if (!ValidateArguments(inputPath, outputPath, size, padding))
+		string inputDir = inputPath.ToString();
+		string outputDir = outputPath.ToString();
+
+		if (!ValidateArguments(inputDir, outputDir, size, padding))
 		{
 			return 0;
 		}
 
 		Rgba32 targetColor = ParseHexColor(color);
-		string[] files = Directory.GetFiles(inputPath);
+		string[] files = Directory.GetFiles(inputDir);
 		int processedCount = 0;
 
 		await AnsiConsole.Progress()
@@ -58,7 +65,7 @@ public static class ImageService
 				foreach (string file in files)
 				{
 					ct.ThrowIfCancellationRequested();
-					bool succeeded = ProcessFileWithErrorHandling(file, outputPath, targetColor, size, padding);
+					bool succeeded = ProcessFileWithErrorHandling(file, outputDir, targetColor, size, padding);
 
 					if (succeeded)
 					{

--- a/KtsuTools.Image/KtsuTools.Image.csproj
+++ b/KtsuTools.Image/KtsuTools.Image.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Spectre.Console" />
     <PackageReference Include="SixLabors.ImageSharp" />
     <PackageReference Include="ktsu.Extensions" />
+    <PackageReference Include="ktsu.Semantics.Paths" />
   </ItemGroup>
 
   <ItemGroup>

--- a/KtsuTools.Markdown/KtsuTools.Markdown.csproj
+++ b/KtsuTools.Markdown/KtsuTools.Markdown.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="YamlDotNet" />
     <PackageReference Include="ktsu.Frontmatter" />
     <PackageReference Include="ktsu.Extensions" />
+    <PackageReference Include="ktsu.Semantics.Paths" />
   </ItemGroup>
 
   <ItemGroup>

--- a/KtsuTools.Markdown/MarkdownService.cs
+++ b/KtsuTools.Markdown/MarkdownService.cs
@@ -7,6 +7,7 @@ namespace KtsuTools.Markdown;
 using Spectre.Console;
 
 using ktsu.Frontmatter;
+using ktsu.Semantics.Paths;
 
 /// <summary>
 /// Service for cleaning and linting markdown files.
@@ -22,10 +23,11 @@ public class MarkdownService
 	/// <param name="ct">Cancellation token.</param>
 	/// <returns>The number of files that were modified.</returns>
 #pragma warning disable CA1822, S2325 // Mark members as static - instance method required for DI injection
-	public async Task<int> CleanAsync(string directoryPath, bool applyLinting, bool standardizeLineEndings, CancellationToken ct)
+	public async Task<int> CleanAsync(AbsoluteDirectoryPath directoryPath, bool applyLinting, bool standardizeLineEndings, CancellationToken ct)
 #pragma warning restore CA1822, S2325
 	{
-		string fullPath = Path.GetFullPath(directoryPath);
+		Ensure.NotNull(directoryPath);
+		string fullPath = directoryPath.ToString();
 
 		if (!Directory.Exists(fullPath))
 		{
@@ -78,10 +80,11 @@ public class MarkdownService
 	/// <param name="ct">Cancellation token.</param>
 	/// <returns>The number of files that were modified.</returns>
 #pragma warning disable CA1822, S2325 // Mark members as static - instance method required for DI injection
-	public async Task<int> LintAsync(string directoryPath, CancellationToken ct)
+	public async Task<int> LintAsync(AbsoluteDirectoryPath directoryPath, CancellationToken ct)
 #pragma warning restore CA1822, S2325
 	{
-		string fullPath = Path.GetFullPath(directoryPath);
+		Ensure.NotNull(directoryPath);
+		string fullPath = directoryPath.ToString();
 
 		if (!Directory.Exists(fullPath))
 		{

--- a/KtsuTools.Packages/KtsuTools.Packages.csproj
+++ b/KtsuTools.Packages/KtsuTools.Packages.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Spectre.Console" />
+    <PackageReference Include="ktsu.Semantics.Paths" />
   </ItemGroup>
 
   <ItemGroup>

--- a/KtsuTools.Packages/PackagesService.cs
+++ b/KtsuTools.Packages/PackagesService.cs
@@ -7,6 +7,7 @@ namespace KtsuTools.Packages;
 using System.Net.Http;
 using System.Text.Json;
 using System.Xml.Linq;
+using ktsu.Semantics.Paths;
 using KtsuTools.Core.Services.Process;
 using Spectre.Console;
 
@@ -21,14 +22,26 @@ public class PackagesService(IProcessService processService)
 	private static readonly HttpClient SharedHttpClient = new();
 
 	/// <summary>
-	/// Updates NuGet packages in projects at the specified path.
+	/// Updates NuGet packages in all .csproj files under the specified directory.
 	/// </summary>
-	public async Task<int> UpdateAsync(string path, bool whatIf = false, bool includePrerelease = false, string source = "nuget", CancellationToken ct = default)
+	public Task<int> UpdateAsync(AbsoluteDirectoryPath path, bool whatIf = false, bool includePrerelease = false, string source = "nuget", CancellationToken ct = default)
+	{
+		Ensure.NotNull(path);
+		return UpdateInternalAsync(path.ToString(), whatIf, includePrerelease, source, ct);
+	}
+
+	/// <summary>
+	/// Updates NuGet packages in a single .csproj file.
+	/// </summary>
+	public Task<int> UpdateAsync(AbsoluteFilePath path, bool whatIf = false, bool includePrerelease = false, string source = "nuget", CancellationToken ct = default)
+	{
+		Ensure.NotNull(path);
+		return UpdateInternalAsync(path.ToString(), whatIf, includePrerelease, source, ct);
+	}
+
+	private async Task<int> UpdateInternalAsync(string fullPath, bool whatIf, bool includePrerelease, string source, CancellationToken ct)
 	{
 		_ = processService;
-		Ensure.NotNull(path);
-
-		string fullPath = Path.GetFullPath(path);
 
 		if (!Directory.Exists(fullPath) && !File.Exists(fullPath))
 		{
@@ -77,12 +90,12 @@ public class PackagesService(IProcessService processService)
 	/// <summary>
 	/// Migrates projects to Central Package Management.
 	/// </summary>
-	public async Task<int> MigrateToCpmAsync(string path, CancellationToken ct = default)
+	public async Task<int> MigrateToCpmAsync(AbsoluteDirectoryPath path, CancellationToken ct = default)
 	{
 		_ = processService;
 		Ensure.NotNull(path);
 
-		string fullPath = Path.GetFullPath(path);
+		string fullPath = path.ToString();
 
 		if (!Directory.Exists(fullPath))
 		{

--- a/KtsuTools.Repo/KtsuTools.Repo.csproj
+++ b/KtsuTools.Repo/KtsuTools.Repo.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Spectre.Console" />
+    <PackageReference Include="ktsu.Semantics.Paths" />
   </ItemGroup>
 
   <ItemGroup>

--- a/KtsuTools.Repo/RepoService.cs
+++ b/KtsuTools.Repo/RepoService.cs
@@ -6,6 +6,7 @@ namespace KtsuTools.Repo;
 
 using System.Collections.Concurrent;
 using System.Collections.ObjectModel;
+using ktsu.Semantics.Paths;
 using KtsuTools.Core.Services.Git;
 using KtsuTools.Core.Services.Process;
 using Spectre.Console;
@@ -38,12 +39,12 @@ public class RepoService(IGitService gitService, IProcessService processService)
 	/// <summary>
 	/// Discovers git repositories in the given directory.
 	/// </summary>
-	public async Task<IReadOnlyList<string>> DiscoverRepositoriesAsync(string path, CancellationToken ct = default)
+	public async Task<IReadOnlyList<string>> DiscoverRepositoriesAsync(AbsoluteDirectoryPath path, CancellationToken ct = default)
 	{
 		_ = gitService;
 		Ensure.NotNull(path);
 
-		string fullPath = Path.GetFullPath(path);
+		string fullPath = path.ToString();
 
 		if (!Directory.Exists(fullPath))
 		{
@@ -85,12 +86,12 @@ public class RepoService(IGitService gitService, IProcessService processService)
 	/// <summary>
 	/// Builds and tests all solutions found in repositories under the given path.
 	/// </summary>
-	public async Task<int> BuildAndTestAsync(string path, bool parallel = false, CancellationToken ct = default)
+	public async Task<int> BuildAndTestAsync(AbsoluteDirectoryPath path, bool parallel = false, CancellationToken ct = default)
 	{
 		_ = parallel;
 		Ensure.NotNull(path);
 
-		string fullPath = Path.GetFullPath(path);
+		string fullPath = path.ToString();
 		List<string> solutionFiles = DiscoverSolutionFiles(fullPath);
 
 		if (solutionFiles.Count == 0)
@@ -157,12 +158,12 @@ public class RepoService(IGitService gitService, IProcessService processService)
 	/// <summary>
 	/// Pulls all repositories under the given path.
 	/// </summary>
-	public async Task<int> PullAllAsync(string path, CancellationToken ct = default)
+	public async Task<int> PullAllAsync(AbsoluteDirectoryPath path, CancellationToken ct = default)
 	{
 		_ = gitService;
 		Ensure.NotNull(path);
 
-		string fullPath = Path.GetFullPath(path);
+		string fullPath = path.ToString();
 		ConcurrentBag<string> repos = [];
 		DiscoverGitReposRecursive(fullPath, repos);
 
@@ -223,11 +224,11 @@ public class RepoService(IGitService gitService, IProcessService processService)
 	/// <summary>
 	/// Updates NuGet packages in all projects under the given path.
 	/// </summary>
-	public async Task<int> UpdatePackagesAsync(string path, bool includePrerelease = false, CancellationToken ct = default)
+	public async Task<int> UpdatePackagesAsync(AbsoluteDirectoryPath path, bool includePrerelease = false, CancellationToken ct = default)
 	{
 		Ensure.NotNull(path);
 
-		string fullPath = Path.GetFullPath(path);
+		string fullPath = path.ToString();
 		List<string> solutionFiles = DiscoverSolutionFiles(fullPath);
 
 		if (solutionFiles.Count == 0)

--- a/KtsuTools.SvnMigrate/KtsuTools.SvnMigrate.csproj
+++ b/KtsuTools.SvnMigrate/KtsuTools.SvnMigrate.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Spectre.Console" />
+    <PackageReference Include="ktsu.Semantics.Paths" />
   </ItemGroup>
 
   <ItemGroup>

--- a/KtsuTools.SvnMigrate/SvnMigrateService.cs
+++ b/KtsuTools.SvnMigrate/SvnMigrateService.cs
@@ -4,6 +4,7 @@
 
 namespace KtsuTools.SvnMigrate;
 
+using ktsu.Semantics.Paths;
 using KtsuTools.Core.Services.Process;
 using Spectre.Console;
 
@@ -17,15 +18,16 @@ public class SvnMigrateService(IProcessService processService)
 	/// <summary>
 	/// Migrates an SVN repository to Git.
 	/// </summary>
-	public async Task<int> MigrateAsync(Uri svnUrl, string targetPath, string? authorsFile = null, bool preserveEmptyDirs = true, CancellationToken ct = default)
+	public async Task<int> MigrateAsync(Uri svnUrl, AbsoluteDirectoryPath targetPath, AbsoluteFilePath? authorsFile = null, bool preserveEmptyDirs = true, CancellationToken ct = default)
 	{
 		Ensure.NotNull(svnUrl);
 		Ensure.NotNull(targetPath);
 
-		string gitRepoPath = Path.GetFullPath(targetPath);
+		string gitRepoPath = targetPath.ToString();
+		string? authorsFilePath = authorsFile?.ToString();
 
 		// Validate prerequisites
-		List<string> errors = await ValidateAsync(svnUrl, gitRepoPath, authorsFile, ct).ConfigureAwait(false);
+		List<string> errors = await ValidateAsync(svnUrl, gitRepoPath, authorsFilePath, ct).ConfigureAwait(false);
 		if (errors.Count > 0)
 		{
 			foreach (string error in errors)
@@ -53,7 +55,7 @@ public class SvnMigrateService(IProcessService processService)
 
 					// Phase 1: Clone SVN repository
 					task.Description = "[green]Cloning SVN repository with git-svn...[/]";
-					await CloneSvnRepositoryAsync(svnUrl.ToString(), gitRepoPath, authorsFile, preserveEmptyDirs, ct).ConfigureAwait(false);
+					await CloneSvnRepositoryAsync(svnUrl.ToString(), gitRepoPath, authorsFilePath, preserveEmptyDirs, ct).ConfigureAwait(false);
 					task.Value = 50;
 
 					// Phase 2: Cleanup references

--- a/KtsuTools.Sync/SyncService.cs
+++ b/KtsuTools.Sync/SyncService.cs
@@ -42,7 +42,7 @@ public class SyncService(IProcessService processService)
 	/// <param name="filename">The filename pattern to scan for.</param>
 	/// <param name="ct">Cancellation token.</param>
 	/// <returns>Exit code (0 for success).</returns>
-	public Task<int> RunAsync(string path, string filename, CancellationToken ct = default) =>
+	public Task<int> RunAsync(AbsoluteDirectoryPath path, string filename, CancellationToken ct = default) =>
 		RunAsync(path, [filename], autoPush: false, ct);
 
 	/// <summary>
@@ -53,13 +53,16 @@ public class SyncService(IProcessService processService)
 	/// <param name="autoPush">When true, repos whose unpushed commits are all authored by KtsuTools are pushed without prompting.</param>
 	/// <param name="ct">Cancellation token.</param>
 	/// <returns>Exit code (0 for success).</returns>
-	public async Task<int> RunAsync(string path, IReadOnlyList<string> filenames, bool autoPush, CancellationToken ct = default)
+	public async Task<int> RunAsync(AbsoluteDirectoryPath path, IReadOnlyList<string> filenames, bool autoPush, CancellationToken ct = default)
 	{
+		Ensure.NotNull(path);
 		ct.ThrowIfCancellationRequested();
 
-		if (!Directory.Exists(path))
+		string pathString = path.ToString();
+
+		if (!Directory.Exists(pathString))
 		{
-			AnsiConsole.MarkupLine($"[red]Path does not exist: {path.EscapeMarkup()}[/]");
+			AnsiConsole.MarkupLine($"[red]Path does not exist: {pathString.EscapeMarkup()}[/]");
 			return 1;
 		}
 
@@ -75,14 +78,14 @@ public class SyncService(IProcessService processService)
 		}
 
 		AnsiConsole.MarkupLine($"[bold]Scanning for:[/] {string.Join(", ", patterns).EscapeMarkup()}");
-		AnsiConsole.MarkupLine($"[bold]In:[/] {path.EscapeMarkup()}");
+		AnsiConsole.MarkupLine($"[bold]In:[/] {pathString.EscapeMarkup()}");
 		AnsiConsole.WriteLine();
 
 		HashSet<string> seen = new(StringComparer.Ordinal);
 		Collection<string> fileEnumeration = [];
 		foreach (string pattern in patterns)
 		{
-			foreach (string file in Directory.EnumerateFiles(path, pattern, SearchOption.AllDirectories)
+			foreach (string file in Directory.EnumerateFiles(pathString, pattern, SearchOption.AllDirectories)
 				.Where(f => !IsRepoNested(AbsoluteFilePath.Create<AbsoluteFilePath>(f).AbsoluteDirectoryPath)))
 			{
 				if (seen.Add(file))
@@ -103,12 +106,12 @@ public class SyncService(IProcessService processService)
 		foreach (string uniqueFilename in uniqueFilenames)
 		{
 			ct.ThrowIfCancellationRequested();
-			await ProcessUniqueFilenameAsync(uniqueFilename, fileEnumeration, path, commitDirectories, ct).ConfigureAwait(false);
+			await ProcessUniqueFilenameAsync(uniqueFilename, fileEnumeration, pathString, commitDirectories, ct).ConfigureAwait(false);
 		}
 
-		await CommitChangedFilesAsync(commitDirectories, expandedFilesToSync, path).ConfigureAwait(false);
+		await CommitChangedFilesAsync(commitDirectories, expandedFilesToSync, pathString).ConfigureAwait(false);
 
-		await PushToRemoteAsync(commitDirectories, path, autoPush, ct).ConfigureAwait(false);
+		await PushToRemoteAsync(commitDirectories, pathString, autoPush, ct).ConfigureAwait(false);
 
 		return 0;
 	}

--- a/KtsuTools.Test/RepoServiceTests.cs
+++ b/KtsuTools.Test/RepoServiceTests.cs
@@ -5,6 +5,7 @@
 namespace KtsuTools.Test;
 
 using System.IO;
+using ktsu.Semantics.Paths;
 using KtsuTools.Core.Services.Git;
 using KtsuTools.Core.Services.Process;
 using KtsuTools.Repo;
@@ -18,7 +19,8 @@ public class RepoServiceTests
 	{
 		RepoService service = new(new Mock<IGitService>().Object, new Mock<IProcessService>().Object);
 		string missing = Path.Combine(Path.GetTempPath(), $"ktsu_missing_{Guid.NewGuid():N}");
-		IReadOnlyList<string> result = await service.DiscoverRepositoriesAsync(missing).ConfigureAwait(false);
+		AbsoluteDirectoryPath missingPath = AbsoluteDirectoryPath.Create<AbsoluteDirectoryPath>(missing);
+		IReadOnlyList<string> result = await service.DiscoverRepositoriesAsync(missingPath).ConfigureAwait(false);
 		Assert.AreEqual(0, result.Count);
 	}
 
@@ -35,7 +37,8 @@ public class RepoServiceTests
 		try
 		{
 			RepoService service = new(new Mock<IGitService>().Object, new Mock<IProcessService>().Object);
-			IReadOnlyList<string> result = await service.DiscoverRepositoriesAsync(root).ConfigureAwait(false);
+			AbsoluteDirectoryPath rootPath = AbsoluteDirectoryPath.Create<AbsoluteDirectoryPath>(root);
+			IReadOnlyList<string> result = await service.DiscoverRepositoriesAsync(rootPath).ConfigureAwait(false);
 			Assert.AreEqual(2, result.Count, "Should find exactly the two .git directories.");
 			CollectionAssert.AreEquivalent(
 				new[] { repoA, repoB },

--- a/KtsuTools/Commands/ImageProcessCommand.cs
+++ b/KtsuTools/Commands/ImageProcessCommand.cs
@@ -5,6 +5,8 @@
 namespace KtsuTools.Commands;
 
 using System.ComponentModel;
+using System.IO;
+using ktsu.Semantics.Paths;
 using KtsuTools.Core.UI;
 using KtsuTools.Image;
 using Spectre.Console;
@@ -44,9 +46,11 @@ public sealed class ImageProcessCommand : AsyncCommand<ImageProcessCommand.Setti
 		AnsiConsole.MarkupLine("[bold]Image Process[/]");
 
 		using CtrlCScope scope = new();
+		AbsoluteDirectoryPath inputPath = AbsoluteDirectoryPath.Create<AbsoluteDirectoryPath>(Path.GetFullPath(settings.InputPath));
+		AbsoluteDirectoryPath outputPath = AbsoluteDirectoryPath.Create<AbsoluteDirectoryPath>(Path.GetFullPath(settings.OutputPath));
 		int processed = await ImageService.ProcessAsync(
-			settings.InputPath,
-			settings.OutputPath,
+			inputPath,
+			outputPath,
 			settings.Color,
 			settings.Size,
 			settings.Padding,

--- a/KtsuTools/Commands/MarkdownCleanCommand.cs
+++ b/KtsuTools/Commands/MarkdownCleanCommand.cs
@@ -5,6 +5,8 @@
 namespace KtsuTools.Commands;
 
 using System.ComponentModel;
+using System.IO;
+using ktsu.Semantics.Paths;
 using KtsuTools.Core.UI;
 using KtsuTools.Markdown;
 using Spectre.Console;
@@ -37,8 +39,9 @@ public sealed class MarkdownCleanCommand(MarkdownService markdownService) : Asyn
 		AnsiConsole.MarkupLine("[bold]Markdown Clean[/]");
 
 		using CtrlCScope scope = new();
+		AbsoluteDirectoryPath path = AbsoluteDirectoryPath.Create<AbsoluteDirectoryPath>(Path.GetFullPath(settings.Path));
 		int modifiedCount = await markdownService.CleanAsync(
-			settings.Path,
+			path,
 			settings.ApplyLinting,
 			settings.StandardizeLineEndings,
 			scope.Token).ConfigureAwait(false);

--- a/KtsuTools/Commands/MarkdownLintCommand.cs
+++ b/KtsuTools/Commands/MarkdownLintCommand.cs
@@ -5,6 +5,8 @@
 namespace KtsuTools.Commands;
 
 using System.ComponentModel;
+using System.IO;
+using ktsu.Semantics.Paths;
 using KtsuTools.Core.UI;
 using KtsuTools.Markdown;
 using Spectre.Console;
@@ -27,8 +29,9 @@ public sealed class MarkdownLintCommand(MarkdownService markdownService) : Async
 		AnsiConsole.MarkupLine("[bold]Markdown Lint[/]");
 
 		using CtrlCScope scope = new();
+		AbsoluteDirectoryPath path = AbsoluteDirectoryPath.Create<AbsoluteDirectoryPath>(Path.GetFullPath(settings.Path));
 		int modifiedCount = await markdownService.LintAsync(
-			settings.Path,
+			path,
 			scope.Token).ConfigureAwait(false);
 
 		AnsiConsole.MarkupLine($"[bold green]Done.[/] {modifiedCount} file(s) linted.");

--- a/KtsuTools/Commands/PackagesMigrateCpmCommand.cs
+++ b/KtsuTools/Commands/PackagesMigrateCpmCommand.cs
@@ -5,6 +5,8 @@
 namespace KtsuTools.Commands;
 
 using System.ComponentModel;
+using System.IO;
+using ktsu.Semantics.Paths;
 using KtsuTools.Core.UI;
 using KtsuTools.Packages;
 using Spectre.Console.Cli;
@@ -24,8 +26,9 @@ public sealed class PackagesMigrateCpmCommand(PackagesService packagesService) :
 	{
 		Ensure.NotNull(settings);
 		using CtrlCScope scope = new();
+		AbsoluteDirectoryPath path = AbsoluteDirectoryPath.Create<AbsoluteDirectoryPath>(Path.GetFullPath(settings.Path));
 		return await packagesService.MigrateToCpmAsync(
-			settings.Path,
+			path,
 			scope.Token).ConfigureAwait(false);
 	}
 }

--- a/KtsuTools/Commands/PackagesUpdateCommand.cs
+++ b/KtsuTools/Commands/PackagesUpdateCommand.cs
@@ -5,6 +5,8 @@
 namespace KtsuTools.Commands;
 
 using System.ComponentModel;
+using System.IO;
+using ktsu.Semantics.Paths;
 using KtsuTools.Core.UI;
 using KtsuTools.Packages;
 using Spectre.Console.Cli;
@@ -39,8 +41,21 @@ public sealed class PackagesUpdateCommand(PackagesService packagesService) : Asy
 	{
 		Ensure.NotNull(settings);
 		using CtrlCScope scope = new();
+		string fullPath = Path.GetFullPath(settings.Path);
+		if (File.Exists(fullPath))
+		{
+			AbsoluteFilePath filePath = AbsoluteFilePath.Create<AbsoluteFilePath>(fullPath);
+			return await packagesService.UpdateAsync(
+				filePath,
+				settings.WhatIf,
+				settings.IncludePrerelease,
+				settings.Source,
+				scope.Token).ConfigureAwait(false);
+		}
+
+		AbsoluteDirectoryPath dirPath = AbsoluteDirectoryPath.Create<AbsoluteDirectoryPath>(fullPath);
 		return await packagesService.UpdateAsync(
-			settings.Path,
+			dirPath,
 			settings.WhatIf,
 			settings.IncludePrerelease,
 			settings.Source,

--- a/KtsuTools/Commands/RepoBuildCommand.cs
+++ b/KtsuTools/Commands/RepoBuildCommand.cs
@@ -5,6 +5,8 @@
 namespace KtsuTools.Commands;
 
 using System.ComponentModel;
+using System.IO;
+using ktsu.Semantics.Paths;
 using KtsuTools.Core.UI;
 using KtsuTools.Repo;
 using Spectre.Console.Cli;
@@ -30,8 +32,9 @@ public sealed class RepoBuildCommand(RepoService repoService) : AsyncCommand<Rep
 	{
 		Ensure.NotNull(settings);
 		using CtrlCScope scope = new();
+		AbsoluteDirectoryPath path = AbsoluteDirectoryPath.Create<AbsoluteDirectoryPath>(Path.GetFullPath(settings.Path));
 		return await repoService.BuildAndTestAsync(
-			settings.Path,
+			path,
 			settings.Parallel,
 			scope.Token).ConfigureAwait(false);
 	}

--- a/KtsuTools/Commands/RepoDiscoverCommand.cs
+++ b/KtsuTools/Commands/RepoDiscoverCommand.cs
@@ -5,6 +5,8 @@
 namespace KtsuTools.Commands;
 
 using System.ComponentModel;
+using System.IO;
+using ktsu.Semantics.Paths;
 using KtsuTools.Core.UI;
 using KtsuTools.Repo;
 using Spectre.Console.Cli;
@@ -25,7 +27,8 @@ public sealed class RepoDiscoverCommand(RepoService repoService) : AsyncCommand<
 	{
 		Ensure.NotNull(settings);
 		using CtrlCScope scope = new();
-		await repoService.DiscoverRepositoriesAsync(settings.Path, scope.Token).ConfigureAwait(false);
+		AbsoluteDirectoryPath path = AbsoluteDirectoryPath.Create<AbsoluteDirectoryPath>(Path.GetFullPath(settings.Path));
+		await repoService.DiscoverRepositoriesAsync(path, scope.Token).ConfigureAwait(false);
 		return 0;
 	}
 }

--- a/KtsuTools/Commands/RepoPullCommand.cs
+++ b/KtsuTools/Commands/RepoPullCommand.cs
@@ -5,6 +5,8 @@
 namespace KtsuTools.Commands;
 
 using System.ComponentModel;
+using System.IO;
+using ktsu.Semantics.Paths;
 using KtsuTools.Core.UI;
 using KtsuTools.Repo;
 using Spectre.Console.Cli;
@@ -25,8 +27,9 @@ public sealed class RepoPullCommand(RepoService repoService) : AsyncCommand<Repo
 	{
 		Ensure.NotNull(settings);
 		using CtrlCScope scope = new();
+		AbsoluteDirectoryPath path = AbsoluteDirectoryPath.Create<AbsoluteDirectoryPath>(Path.GetFullPath(settings.Path));
 		return await repoService.PullAllAsync(
-			settings.Path,
+			path,
 			scope.Token).ConfigureAwait(false);
 	}
 }

--- a/KtsuTools/Commands/RepoUpdatePackagesCommand.cs
+++ b/KtsuTools/Commands/RepoUpdatePackagesCommand.cs
@@ -5,6 +5,8 @@
 namespace KtsuTools.Commands;
 
 using System.ComponentModel;
+using System.IO;
+using ktsu.Semantics.Paths;
 using KtsuTools.Core.UI;
 using KtsuTools.Repo;
 using Spectre.Console.Cli;
@@ -30,8 +32,9 @@ public sealed class RepoUpdatePackagesCommand(RepoService repoService) : AsyncCo
 	{
 		Ensure.NotNull(settings);
 		using CtrlCScope scope = new();
+		AbsoluteDirectoryPath path = AbsoluteDirectoryPath.Create<AbsoluteDirectoryPath>(Path.GetFullPath(settings.Path));
 		return await repoService.UpdatePackagesAsync(
-			settings.Path,
+			path,
 			settings.IncludePrerelease,
 			scope.Token).ConfigureAwait(false);
 	}

--- a/KtsuTools/Commands/SvnMigrateCommand.cs
+++ b/KtsuTools/Commands/SvnMigrateCommand.cs
@@ -6,6 +6,8 @@ namespace KtsuTools.Commands;
 
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using ktsu.Semantics.Paths;
 using KtsuTools.Core.UI;
 using KtsuTools.SvnMigrate;
 using Spectre.Console.Cli;
@@ -39,10 +41,14 @@ public sealed class SvnMigrateCommand(SvnMigrateService svnMigrateService) : Asy
 	{
 		Ensure.NotNull(settings);
 		using CtrlCScope scope = new();
+		AbsoluteDirectoryPath targetPath = AbsoluteDirectoryPath.Create<AbsoluteDirectoryPath>(Path.GetFullPath(settings.TargetPath));
+		AbsoluteFilePath? authorsFile = string.IsNullOrWhiteSpace(settings.AuthorsFile)
+			? null
+			: AbsoluteFilePath.Create<AbsoluteFilePath>(Path.GetFullPath(settings.AuthorsFile));
 		return await svnMigrateService.MigrateAsync(
 			new Uri(settings.SvnUrl),
-			settings.TargetPath,
-			settings.AuthorsFile,
+			targetPath,
+			authorsFile,
 			settings.PreserveEmptyDirs,
 			scope.Token).ConfigureAwait(false);
 	}

--- a/KtsuTools/Commands/SyncCommand.cs
+++ b/KtsuTools/Commands/SyncCommand.cs
@@ -7,8 +7,10 @@ namespace KtsuTools.Commands;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using ktsu.Semantics.Paths;
 using KtsuTools.Core.UI;
 using KtsuTools.Sync;
 using Spectre.Console;
@@ -67,7 +69,8 @@ public sealed class SyncCommand(SyncService syncService) : AsyncCommand<SyncComm
 		}
 
 		using CtrlCScope scope = new();
-		return await syncService.RunAsync(path, filenames, settings.AutoPush, scope.Token).ConfigureAwait(false);
+		AbsoluteDirectoryPath rootPath = AbsoluteDirectoryPath.Create<AbsoluteDirectoryPath>(Path.GetFullPath(path));
+		return await syncService.RunAsync(rootPath, filenames, settings.AutoPush, scope.Token).ConfigureAwait(false);
 	}
 
 	private static List<string> ExpandFilenames(IEnumerable<string> raw) =>


### PR DESCRIPTION
## Summary

Closes #14. Public service entry points across the codebase now accept `AbsoluteDirectoryPath` / `AbsoluteFilePath` from `ktsu.Semantics.Paths` instead of raw `string`, with conversion handled at the Spectre command boundary (mirroring the pattern already used by `MergeCommand` / `CodeGenCommand` / `ExplorerCommand`).

### Service signatures migrated
- `MarkdownService.CleanAsync` / `LintAsync` — `AbsoluteDirectoryPath`
- `RepoService.DiscoverRepositoriesAsync` / `BuildAndTestAsync` / `PullAllAsync` / `UpdatePackagesAsync` — `AbsoluteDirectoryPath`
- `PackagesService.UpdateAsync` — overloads for `AbsoluteDirectoryPath` and `AbsoluteFilePath` (single `.csproj`)
- `PackagesService.MigrateToCpmAsync` — `AbsoluteDirectoryPath`
- `SvnMigrateService.MigrateAsync` — `AbsoluteDirectoryPath` target + optional `AbsoluteFilePath` authors file
- `ImageService.ProcessAsync` — `AbsoluteDirectoryPath` for input + output
- `SyncService.RunAsync` — `AbsoluteDirectoryPath` (was the only remaining `string` entry point in the project the issue called out)

### Command boundary
Each corresponding `*Command.cs` calls `AbsoluteDirectoryPath.Create<...>(Path.GetFullPath(settings.Path))` (or `AbsoluteFilePath.Create<...>(...)`) once before delegating to the service. `PackagesUpdateCommand` chooses the file vs. directory overload based on `File.Exists` to preserve current behaviour where the user can pass a single `.csproj`.

### csproj
Added `ktsu.Semantics.Paths` package reference to `KtsuTools.Markdown`, `KtsuTools.Repo`, `KtsuTools.Packages`, `KtsuTools.SvnMigrate`, and `KtsuTools.Image`.

### Tests
Updated `RepoServiceTests` for the new `DiscoverRepositoriesAsync(AbsoluteDirectoryPath)` signature. Other test files (`MergeServiceTests`, `SyncServiceTests`, `CodeGenServiceTests`, `ImageServiceTests`, `MarkdownLintTests`, `SmokeTests`) either already used the strong-path types or do not exercise the changed entry points.

### Out of scope (per issue)
`Path.GetFileName` / `Path.Combine` calls that operate on `string` results from `Directory.EnumerateFiles` etc. are kept — the issue explicitly excludes those.

## Test plan

- [ ] CI builds the solution successfully (.NET wasn't available in my environment to build locally)
- [ ] Existing unit tests still pass
- [ ] Manual smoke: each migrated command (`ktsu markdown clean`, `ktsu repo discover`, `ktsu packages update`, `ktsu svn-migrate`, `ktsu image process`, `ktsu sync`) accepts a relative path and works end-to-end

https://claude.ai/code/session_015z5JX7CrrvNdfjWDZNV3Hy

---
_Generated by [Claude Code](https://claude.ai/code/session_015z5JX7CrrvNdfjWDZNV3Hy)_