### PR TITLE
Address audit follow-ups for #8, #9, #15 (with batch CRUD for ktsu merge)

### DIFF
--- a/KtsuTools.Merge/MergeBatchService.cs
+++ b/KtsuTools.Merge/MergeBatchService.cs
@@ -1,0 +1,45 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace KtsuTools.Merge;
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using KtsuTools.Core.Services.Settings;
+
+public class MergeBatchService(ISettingsService settingsService)
+{
+	private readonly ISettingsService _settings = settingsService;
+	private MergeBatchSettings? _store;
+
+	public IReadOnlyDictionary<string, MergeBatchEntry> List() => GetStore().Batches;
+
+	public MergeBatchEntry? Get(string name) =>
+		GetStore().Batches.TryGetValue(name, out MergeBatchEntry? entry) ? entry : null;
+
+	public async Task SaveAsync(string name, MergeBatchEntry entry, CancellationToken ct = default)
+	{
+		Ensure.NotNull(name);
+		Ensure.NotNull(entry);
+		MergeBatchSettings store = GetStore();
+		store.Batches[name] = entry;
+		await _settings.SaveAsync(store).ConfigureAwait(false);
+	}
+
+	public async Task<bool> DeleteAsync(string name, CancellationToken ct = default)
+	{
+		Ensure.NotNull(name);
+		MergeBatchSettings store = GetStore();
+		if (!store.Batches.Remove(name))
+		{
+			return false;
+		}
+
+		await _settings.SaveAsync(store).ConfigureAwait(false);
+		return true;
+	}
+
+	private MergeBatchSettings GetStore() => _store ??= _settings.LoadOrCreate<MergeBatchSettings>();
+}

--- a/KtsuTools.Merge/MergeBatchSettings.cs
+++ b/KtsuTools.Merge/MergeBatchSettings.cs
@@ -1,0 +1,20 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace KtsuTools.Merge;
+
+using System.Collections.Generic;
+using ktsu.AppDataStorage;
+
+public sealed record MergeBatchEntry
+{
+	public required string Directory { get; init; }
+	public required string Filename { get; init; }
+	public string? DiffStyle { get; init; }
+}
+
+public class MergeBatchSettings : AppData<MergeBatchSettings>
+{
+	public Dictionary<string, MergeBatchEntry> Batches { get; init; } = [];
+}

--- a/KtsuTools.Test/MergeBatchServiceTests.cs
+++ b/KtsuTools.Test/MergeBatchServiceTests.cs
@@ -1,0 +1,87 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace KtsuTools.Test;
+
+using KtsuTools.Core.Services.Settings;
+using KtsuTools.Merge;
+using Moq;
+
+[TestClass]
+public class MergeBatchServiceTests
+{
+	private static (MergeBatchService Service, MergeBatchSettings Store, Mock<ISettingsService> SettingsMock) BuildService()
+	{
+		MergeBatchSettings store = new();
+		Mock<ISettingsService> settings = new();
+		settings.Setup(s => s.LoadOrCreate<MergeBatchSettings>()).Returns(store);
+		settings.Setup(s => s.SaveAsync(It.IsAny<MergeBatchSettings>())).Returns(Task.CompletedTask);
+		MergeBatchService service = new(settings.Object);
+		return (service, store, settings);
+	}
+
+	[TestMethod]
+	public async Task SaveListShowDeleteRoundTrip()
+	{
+		(MergeBatchService service, MergeBatchSettings store, Mock<ISettingsService> settings) = BuildService();
+
+		MergeBatchEntry entry = new()
+		{
+			Directory = "/tmp/repos",
+			Filename = "*.yml",
+			DiffStyle = "side-by-side",
+		};
+
+		await service.SaveAsync("ci-yaml", entry).ConfigureAwait(false);
+
+		Assert.AreEqual(1, service.List().Count);
+		Assert.IsTrue(service.List().ContainsKey("ci-yaml"));
+
+		MergeBatchEntry? loaded = service.Get("ci-yaml");
+		Assert.IsNotNull(loaded);
+		Assert.AreEqual("/tmp/repos", loaded.Directory);
+		Assert.AreEqual("*.yml", loaded.Filename);
+		Assert.AreEqual("side-by-side", loaded.DiffStyle);
+
+		bool removed = await service.DeleteAsync("ci-yaml").ConfigureAwait(false);
+		Assert.IsTrue(removed);
+		Assert.AreEqual(0, service.List().Count);
+		Assert.IsNull(service.Get("ci-yaml"));
+
+		settings.Verify(s => s.SaveAsync(store), Times.Exactly(2));
+	}
+
+	[TestMethod]
+	public async Task DeleteUnknownReturnsFalseAndDoesNotPersist()
+	{
+		(MergeBatchService service, _, Mock<ISettingsService> settings) = BuildService();
+
+		bool removed = await service.DeleteAsync("missing").ConfigureAwait(false);
+
+		Assert.IsFalse(removed);
+		settings.Verify(s => s.SaveAsync(It.IsAny<MergeBatchSettings>()), Times.Never);
+	}
+
+	[TestMethod]
+	public void GetUnknownReturnsNull()
+	{
+		(MergeBatchService service, _, _) = BuildService();
+		Assert.IsNull(service.Get("nope"));
+	}
+
+	[TestMethod]
+	public async Task SaveOverwritesExistingEntry()
+	{
+		(MergeBatchService service, _, _) = BuildService();
+
+		await service.SaveAsync("name", new MergeBatchEntry { Directory = "a", Filename = "b" }).ConfigureAwait(false);
+		await service.SaveAsync("name", new MergeBatchEntry { Directory = "c", Filename = "d", DiffStyle = "git" }).ConfigureAwait(false);
+
+		MergeBatchEntry? loaded = service.Get("name");
+		Assert.IsNotNull(loaded);
+		Assert.AreEqual("c", loaded.Directory);
+		Assert.AreEqual("d", loaded.Filename);
+		Assert.AreEqual("git", loaded.DiffStyle);
+	}
+}

--- a/KtsuTools/Commands/MergeBatchDeleteCommand.cs
+++ b/KtsuTools/Commands/MergeBatchDeleteCommand.cs
@@ -1,0 +1,39 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace KtsuTools.Commands;
+
+using System.ComponentModel;
+using KtsuTools.Core.UI;
+using KtsuTools.Merge;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+public sealed class MergeBatchDeleteCommand(MergeBatchService batchService) : AsyncCommand<MergeBatchDeleteCommand.Settings>
+{
+	private readonly MergeBatchService batchService = batchService;
+
+	public sealed class Settings : CommandSettings
+	{
+		[CommandArgument(0, "<name>")]
+		[Description("Name of the batch to delete")]
+		public required string Name { get; init; }
+	}
+
+	public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
+	{
+		Ensure.NotNull(settings);
+		using CtrlCScope scope = new();
+
+		bool removed = await batchService.DeleteAsync(settings.Name, scope.Token).ConfigureAwait(false);
+		if (!removed)
+		{
+			AnsiConsole.MarkupLine($"[red]No batch named '{settings.Name.EscapeMarkup()}'.[/]");
+			return 1;
+		}
+
+		AnsiConsole.MarkupLine($"[green]Deleted batch '{settings.Name.EscapeMarkup()}'.[/]");
+		return 0;
+	}
+}

--- a/KtsuTools/Commands/MergeBatchListCommand.cs
+++ b/KtsuTools/Commands/MergeBatchListCommand.cs
@@ -1,0 +1,48 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace KtsuTools.Commands;
+
+using System.Collections.Generic;
+using KtsuTools.Merge;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+public sealed class MergeBatchListCommand(MergeBatchService batchService) : Command<MergeBatchListCommand.Settings>
+{
+	private readonly MergeBatchService batchService = batchService;
+
+	public sealed class Settings : CommandSettings
+	{
+	}
+
+	public override int Execute(CommandContext context, Settings settings)
+	{
+		IReadOnlyDictionary<string, MergeBatchEntry> batches = batchService.List();
+
+		if (batches.Count == 0)
+		{
+			AnsiConsole.MarkupLine("[dim]No saved batches. Use 'merge-batch save <name> <directory> <filename>' to create one.[/]");
+			return 0;
+		}
+
+		Table table = new();
+		table.AddColumn("Name");
+		table.AddColumn("Directory");
+		table.AddColumn("Filename");
+		table.AddColumn("Diff Style");
+
+		foreach (KeyValuePair<string, MergeBatchEntry> kvp in batches)
+		{
+			table.AddRow(
+				kvp.Key.EscapeMarkup(),
+				kvp.Value.Directory.EscapeMarkup(),
+				kvp.Value.Filename.EscapeMarkup(),
+				(kvp.Value.DiffStyle ?? "(default)").EscapeMarkup());
+		}
+
+		AnsiConsole.Write(table);
+		return 0;
+	}
+}

--- a/KtsuTools/Commands/MergeBatchSaveCommand.cs
+++ b/KtsuTools/Commands/MergeBatchSaveCommand.cs
@@ -1,0 +1,52 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace KtsuTools.Commands;
+
+using System.ComponentModel;
+using KtsuTools.Core.UI;
+using KtsuTools.Merge;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+public sealed class MergeBatchSaveCommand(MergeBatchService batchService) : AsyncCommand<MergeBatchSaveCommand.Settings>
+{
+	private readonly MergeBatchService batchService = batchService;
+
+	public sealed class Settings : CommandSettings
+	{
+		[CommandArgument(0, "<name>")]
+		[Description("Name to save this batch under")]
+		public required string Name { get; init; }
+
+		[CommandArgument(1, "<directory>")]
+		[Description("Directory containing files to merge")]
+		public required string Directory { get; init; }
+
+		[CommandArgument(2, "<filename>")]
+		[Description("Filename pattern to merge")]
+		public required string Filename { get; init; }
+
+		[CommandOption("--diff-style <STYLE>")]
+		[Description("Diff style to use when running this batch (reserved for future use)")]
+		public string? DiffStyle { get; init; }
+	}
+
+	public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
+	{
+		Ensure.NotNull(settings);
+		using CtrlCScope scope = new();
+
+		MergeBatchEntry entry = new()
+		{
+			Directory = settings.Directory,
+			Filename = settings.Filename,
+			DiffStyle = settings.DiffStyle,
+		};
+
+		await batchService.SaveAsync(settings.Name, entry, scope.Token).ConfigureAwait(false);
+		AnsiConsole.MarkupLine($"[green]Saved batch '{settings.Name.EscapeMarkup()}'.[/]");
+		return 0;
+	}
+}

--- a/KtsuTools/Commands/MergeBatchShowCommand.cs
+++ b/KtsuTools/Commands/MergeBatchShowCommand.cs
@@ -1,0 +1,40 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace KtsuTools.Commands;
+
+using System.ComponentModel;
+using KtsuTools.Merge;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+public sealed class MergeBatchShowCommand(MergeBatchService batchService) : Command<MergeBatchShowCommand.Settings>
+{
+	private readonly MergeBatchService batchService = batchService;
+
+	public sealed class Settings : CommandSettings
+	{
+		[CommandArgument(0, "<name>")]
+		[Description("Name of the batch to show")]
+		public required string Name { get; init; }
+	}
+
+	public override int Execute(CommandContext context, Settings settings)
+	{
+		Ensure.NotNull(settings);
+		MergeBatchEntry? entry = batchService.Get(settings.Name);
+
+		if (entry is null)
+		{
+			AnsiConsole.MarkupLine($"[red]No batch named '{settings.Name.EscapeMarkup()}'.[/]");
+			return 1;
+		}
+
+		AnsiConsole.MarkupLine($"[bold]Batch:[/] {settings.Name.EscapeMarkup()}");
+		AnsiConsole.MarkupLine($"  [dim]Directory:[/]  {entry.Directory.EscapeMarkup()}");
+		AnsiConsole.MarkupLine($"  [dim]Filename:[/]   {entry.Filename.EscapeMarkup()}");
+		AnsiConsole.MarkupLine($"  [dim]Diff style:[/] {(entry.DiffStyle ?? "(default)").EscapeMarkup()}");
+		return 0;
+	}
+}

--- a/KtsuTools/Commands/MergeCommand.cs
+++ b/KtsuTools/Commands/MergeCommand.cs
@@ -9,31 +9,86 @@ using System.IO;
 using ktsu.Semantics.Paths;
 using KtsuTools.Core.UI;
 using KtsuTools.Merge;
+using Spectre.Console;
 using Spectre.Console.Cli;
 
-public sealed class MergeCommand(MergeService mergeService) : AsyncCommand<MergeCommand.Settings>
+public sealed class MergeCommand(MergeService mergeService, MergeBatchService batchService) : AsyncCommand<MergeCommand.Settings>
 {
 	private readonly MergeService mergeService = mergeService;
+	private readonly MergeBatchService batchService = batchService;
 
 	public sealed class Settings : CommandSettings
 	{
-		[CommandArgument(0, "<directory>")]
+		[CommandArgument(0, "[directory]")]
 		[Description("Directory containing files to merge")]
-		public required string Directory { get; init; }
+		public string? Directory { get; init; }
 
-		[CommandArgument(1, "<filename>")]
+		[CommandArgument(1, "[filename]")]
 		[Description("Filename pattern to merge")]
-		public required string Filename { get; init; }
+		public string? Filename { get; init; }
+
+		[CommandOption("--batch <NAME>")]
+		[Description("Run a saved batch by name (use 'merge-batch save' to create one)")]
+		public string? BatchName { get; init; }
+
+		public override ValidationResult Validate()
+		{
+			bool hasDirectory = !string.IsNullOrWhiteSpace(Directory);
+			bool hasFilename = !string.IsNullOrWhiteSpace(Filename);
+			bool hasBatch = !string.IsNullOrWhiteSpace(BatchName);
+
+			if (hasDirectory != hasFilename)
+			{
+				return ValidationResult.Error("Both <directory> and <filename> must be provided together.");
+			}
+
+			bool hasPositional = hasDirectory && hasFilename;
+
+			if (hasPositional && hasBatch)
+			{
+				return ValidationResult.Error("--batch is mutually exclusive with positional <directory> <filename>.");
+			}
+
+			if (!hasPositional && !hasBatch)
+			{
+				return ValidationResult.Error("Provide either <directory> <filename> or --batch <name>.");
+			}
+
+			return ValidationResult.Success();
+		}
 	}
 
 	public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
 	{
 		Ensure.NotNull(settings);
 		using CtrlCScope scope = new();
-		AbsoluteDirectoryPath directory = AbsoluteDirectoryPath.Create<AbsoluteDirectoryPath>(Path.GetFullPath(settings.Directory));
+
+		string directoryArg;
+		string filenameArg;
+
+		if (!string.IsNullOrWhiteSpace(settings.BatchName))
+		{
+			MergeBatchEntry? entry = batchService.Get(settings.BatchName);
+			if (entry is null)
+			{
+				AnsiConsole.MarkupLine($"[red]Error: no batch named '{settings.BatchName.EscapeMarkup()}'. Run 'merge-batch list' to see saved batches.[/]");
+				return 1;
+			}
+
+			directoryArg = entry.Directory;
+			filenameArg = entry.Filename;
+			AnsiConsole.MarkupLine($"[dim]Running batch '{settings.BatchName.EscapeMarkup()}': {directoryArg.EscapeMarkup()} / {filenameArg.EscapeMarkup()}[/]");
+		}
+		else
+		{
+			directoryArg = settings.Directory!;
+			filenameArg = settings.Filename!;
+		}
+
+		AbsoluteDirectoryPath directory = AbsoluteDirectoryPath.Create<AbsoluteDirectoryPath>(Path.GetFullPath(directoryArg));
 		return await mergeService.RunMergeAsync(
 			directory,
-			settings.Filename,
+			filenameArg,
 			scope.Token).ConfigureAwait(false);
 	}
 }

--- a/KtsuTools/Program.cs
+++ b/KtsuTools/Program.cs
@@ -32,6 +32,7 @@ internal static class Program
 		// Feature services
 		services.AddSingleton<MarkdownService>();
 		services.AddSingleton<MergeService>();
+		services.AddSingleton<MergeBatchService>();
 		services.AddSingleton<PackagesService>();
 		services.AddSingleton<SvnMigrateService>();
 		services.AddSingleton<FileExplorerService>();
@@ -57,7 +58,29 @@ internal static class Program
 
 			config.AddCommand<MergeCommand>("merge")
 				.WithDescription("N-way iterative file merge with interactive conflict resolution")
-				.WithExample("merge", "./repos", "*.yml");
+				.WithExample("merge", "./repos", "*.yml")
+				.WithExample("merge", "--batch", "editorconfig-sync");
+
+			config.AddBranch("merge-batch", batch =>
+			{
+				batch.SetDescription("Manage saved merge batches");
+
+				batch.AddCommand<MergeBatchSaveCommand>("save")
+					.WithDescription("Save a named batch of merge inputs")
+					.WithExample("merge-batch", "save", "editorconfig-sync", "./repos", ".editorconfig");
+
+				batch.AddCommand<MergeBatchListCommand>("list")
+					.WithDescription("List all saved merge batches")
+					.WithExample("merge-batch", "list");
+
+				batch.AddCommand<MergeBatchShowCommand>("show")
+					.WithDescription("Show details for a saved batch")
+					.WithExample("merge-batch", "show", "editorconfig-sync");
+
+				batch.AddCommand<MergeBatchDeleteCommand>("delete")
+					.WithDescription("Delete a saved batch")
+					.WithExample("merge-batch", "delete", "editorconfig-sync");
+			});
 
 			config.AddCommand<CodeGenCommand>("codegen")
 				.WithDescription("Generate code from AST/YAML definitions")

--- a/README.md
+++ b/README.md
@@ -9,3 +9,7 @@ ktools <command> [options]
 ```
 
 Run `ktools --help` for a list of available commands.
+
+## Related tools
+
+For per-repo release automation (semver bumps, changelog, publish, package manifest emission), see [KtsuBuild](https://github.com/ktsu-dev/KtsuBuild). KtsuTools focuses on cross-repo orchestration; KtsuBuild handles the inside-one-repo release workflow. The two are complementary and intentionally not merged.


### PR DESCRIPTION
Follow-up to the audits posted on #8, #9, #15. The decisions made there were:

- **#8** — keep KtsuTools.Repo as-is, drop the menu/pwsh items, file the `--parallel` wiring as a follow-up (filed as #35).
- **#9** — keep KtsuBuild standalone (Option 2). Document the split in README.
- **#15** — drop the top-level menu, split the rest into A (#36, batch CRUD), B (#37, `--diff-style`), C (#38, history persistence). Start on A.

> Note: an earlier draft of this description said #36 closes #2. It doesn't — #2 was already closed on 2026-05-03 by *removing* the dead `--batch` flag. #36 re-adds the flag with real semantics.

## What's in this PR
- README pointer to KtsuBuild explaining the deliberate split (resolves the actionable part of #9).
- (incoming on this branch) Implementation of batch CRUD for `ktsu merge` per #36.

## Test plan
- [ ] `ktools --help` still lists `merge` correctly.
- [ ] `ktools merge batch save / list / show / delete` round-trip through `ISettingsService`.
- [ ] `ktools merge --batch <name>` runs a saved batch.
- [ ] Mutual-exclusion: positional args + `--batch` errors with a clear message.
- [ ] Existing `ktools merge <dir> <file>` invocation unchanged.

https://claude.ai/code/session_015z5JX7CrrvNdfjWDZNV3Hy