### PR TITLE
Close #7, #35, #37: dedup command, parallel repo build, merge --diff-style

### DIFF
--- a/KtsuTools.FileDedupe/FileDedupeService.cs
+++ b/KtsuTools.FileDedupe/FileDedupeService.cs
@@ -1,0 +1,172 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace KtsuTools.FileDedupe;
+
+using System.Collections.Concurrent;
+using System.Collections.ObjectModel;
+using System.Security.Cryptography;
+using ktsu.Semantics.Paths;
+using Spectre.Console;
+
+/// <summary>
+/// A set of files with byte-identical content, identified by SHA256.
+/// </summary>
+public sealed record DuplicateGroup(string Hash, long FileSize, Collection<string> Files);
+
+/// <summary>
+/// Result of a dedupe planning pass.
+/// </summary>
+public sealed record DedupePlan(
+	IReadOnlyList<DuplicateGroup> Groups,
+	IReadOnlyList<string> Keepers,
+	IReadOnlyList<string> Removals)
+{
+	public long WastedBytes { get; } = ComputeWastedBytes(Groups);
+
+	private static long ComputeWastedBytes(IReadOnlyList<DuplicateGroup> groups)
+	{
+		long total = 0;
+		foreach (DuplicateGroup g in groups)
+		{
+			total += g.FileSize * (g.Files.Count - 1);
+		}
+
+		return total;
+	}
+}
+
+public sealed record DedupeStats(
+	int FilesScanned,
+	int DuplicateGroups,
+	int RedundantFiles,
+	long WastedBytes,
+	Dictionary<string, int> CountByExtension);
+
+/// <summary>
+/// Scans a directory tree, groups files by SHA256, and applies (or previews)
+/// "shortest filename wins" deduplication.
+/// </summary>
+public class FileDedupeService
+{
+#pragma warning disable CA1822 // instance method required for DI injection
+	public async Task<DedupePlan> PlanAsync(AbsoluteDirectoryPath path, CancellationToken ct = default)
+#pragma warning restore CA1822
+	{
+		Ensure.NotNull(path);
+
+		string root = path.ToString();
+		if (!Directory.Exists(root))
+		{
+			AnsiConsole.MarkupLine($"[red]Error: Directory '{root.EscapeMarkup()}' does not exist.[/]");
+			return new DedupePlan([], [], []);
+		}
+
+		string[] files = Directory.GetFiles(root, "*", SearchOption.AllDirectories);
+
+		ConcurrentDictionary<string, ConcurrentBag<(string Path, long Size)>> byHash = new();
+
+		await Parallel.ForEachAsync(
+			files,
+			new ParallelOptions { CancellationToken = ct, MaxDegreeOfParallelism = Environment.ProcessorCount },
+			async (file, token) =>
+			{
+				try
+				{
+					await using FileStream stream = File.OpenRead(file);
+					byte[] hashBytes = await SHA256.HashDataAsync(stream, token).ConfigureAwait(false);
+					string hash = Convert.ToHexString(hashBytes);
+					long size = new FileInfo(file).Length;
+
+					ConcurrentBag<(string Path, long Size)> bag = byHash.GetOrAdd(hash, _ => []);
+					bag.Add((file, size));
+				}
+				catch (IOException)
+				{
+					// Skip unreadable files (locked, deleted mid-scan, etc.).
+				}
+				catch (UnauthorizedAccessException)
+				{
+				}
+			}).ConfigureAwait(false);
+
+		List<DuplicateGroup> groups = [];
+		List<string> keepers = [];
+		List<string> removals = [];
+
+		foreach ((string hash, ConcurrentBag<(string Path, long Size)> entries) in byHash)
+		{
+			if (entries.Count < 2)
+			{
+				continue;
+			}
+
+			List<string> paths = [.. entries.Select(e => e.Path)
+				.OrderBy(p => Path.GetFileName(p).Length)
+				.ThenBy(p => p, StringComparer.OrdinalIgnoreCase)];
+
+			long size = entries.First().Size;
+			groups.Add(new DuplicateGroup(hash, size, [.. paths]));
+
+			keepers.Add(paths[0]);
+			removals.AddRange(paths.Skip(1));
+		}
+
+		return new DedupePlan(groups, keepers, removals);
+	}
+
+#pragma warning disable CA1822
+	public DedupeStats Summarize(DedupePlan plan, int filesScanned)
+#pragma warning restore CA1822
+	{
+		Ensure.NotNull(plan);
+
+		Dictionary<string, int> byExt = new(StringComparer.OrdinalIgnoreCase);
+		int redundant = 0;
+
+		foreach (DuplicateGroup group in plan.Groups)
+		{
+			redundant += group.Files.Count - 1;
+			foreach (string file in group.Files)
+			{
+				string ext = Path.GetExtension(file);
+				if (string.IsNullOrEmpty(ext))
+				{
+					ext = "(none)";
+				}
+
+				byExt[ext] = byExt.TryGetValue(ext, out int c) ? c + 1 : 1;
+			}
+		}
+
+		return new DedupeStats(filesScanned, plan.Groups.Count, redundant, plan.WastedBytes, byExt);
+	}
+
+#pragma warning disable CA1822
+	public int DeleteRedundant(DedupePlan plan)
+#pragma warning restore CA1822
+	{
+		Ensure.NotNull(plan);
+
+		int deleted = 0;
+		foreach (string path in plan.Removals)
+		{
+			try
+			{
+				File.Delete(path);
+				deleted++;
+			}
+			catch (IOException ex)
+			{
+				AnsiConsole.MarkupLine($"  [yellow]skip[/] {path.EscapeMarkup()}: {ex.Message.EscapeMarkup()}");
+			}
+			catch (UnauthorizedAccessException ex)
+			{
+				AnsiConsole.MarkupLine($"  [yellow]skip[/] {path.EscapeMarkup()}: {ex.Message.EscapeMarkup()}");
+			}
+		}
+
+		return deleted;
+	}
+}

--- a/KtsuTools.FileDedupe/KtsuTools.FileDedupe.csproj
+++ b/KtsuTools.FileDedupe/KtsuTools.FileDedupe.csproj
@@ -1,0 +1,19 @@
+<Project>
+  <Sdk Name="Microsoft.NET.Sdk" />
+  <Sdk Name="ktsu.Sdk" />
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks></TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Spectre.Console" />
+    <PackageReference Include="ktsu.Semantics.Paths" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\KtsuTools.Core\KtsuTools.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/KtsuTools.Merge/DiffStyleParser.cs
+++ b/KtsuTools.Merge/DiffStyleParser.cs
@@ -1,0 +1,48 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace KtsuTools.Merge;
+
+using System;
+
+/// <summary>
+/// Maps the string form of <see cref="DiffStyle"/> used in CLI flags and persisted batch
+/// configs (e.g. "side-by-side", "git") to the enum and back.
+/// </summary>
+public static class DiffStyleParser
+{
+	public const string SideBySideName = "side-by-side";
+	public const string GitName = "git";
+
+	public static bool TryParse(string? value, out DiffStyle style)
+	{
+		if (string.IsNullOrWhiteSpace(value))
+		{
+			style = DiffStyle.SideBySide;
+			return true;
+		}
+
+		switch (value.Trim().ToLowerInvariant())
+		{
+			case SideBySideName:
+			case "sidebyside":
+			case "side":
+				style = DiffStyle.SideBySide;
+				return true;
+			case GitName:
+			case "unified":
+				style = DiffStyle.Git;
+				return true;
+			default:
+				style = DiffStyle.SideBySide;
+				return false;
+		}
+	}
+
+	public static string ToCanonicalString(DiffStyle style) => style switch
+	{
+		DiffStyle.Git => GitName,
+		_ => SideBySideName,
+	};
+}

--- a/KtsuTools.Merge/MergeService.cs
+++ b/KtsuTools.Merge/MergeService.cs
@@ -42,6 +42,18 @@ public enum BlockChoice
 }
 
 /// <summary>
+/// Diff rendering style for conflict display.
+/// </summary>
+public enum DiffStyle
+{
+	/// <summary>DiffPlex side-by-side renderer (default; preserves prior behaviour).</summary>
+	SideBySide,
+
+	/// <summary>Git-style unified diff via DiffPlex UnifiedDiffBuilder.</summary>
+	Git,
+}
+
+/// <summary>
 /// Service for N-way iterative file merging with interactive conflict resolution.
 /// </summary>
 public class MergeService
@@ -51,10 +63,11 @@ public class MergeService
 	/// </summary>
 	/// <param name="directory">Absolute root directory under which to search.</param>
 	/// <param name="filename">Glob pattern to match against filenames.</param>
+	/// <param name="diffStyle">How to render conflict diffs.</param>
 	/// <param name="ct">Cancellation token.</param>
 	/// <returns>Exit code (0 for success).</returns>
 #pragma warning disable CA1822 // Mark members as static - instance method required for DI injection
-	public async Task<int> RunMergeAsync(AbsoluteDirectoryPath directory, string filename, CancellationToken ct = default)
+	public async Task<int> RunMergeAsync(AbsoluteDirectoryPath directory, string filename, DiffStyle diffStyle = DiffStyle.SideBySide, CancellationToken ct = default)
 #pragma warning restore CA1822
 	{
 		Ensure.NotNull(directory);
@@ -113,7 +126,7 @@ public class MergeService
 			string content2 = await File.ReadAllTextAsync(bestPair.FilePath2, ct).ConfigureAwait(false);
 
 			// Show diff
-			ShowDiff(content1, content2, bestPair.FilePath1, bestPair.FilePath2);
+			ShowDiff(content1, content2, bestPair.FilePath1, bestPair.FilePath2, diffStyle);
 
 			// Interactive merge
 			string mergedContent = InteractiveMerge(content1, content2);
@@ -235,15 +248,34 @@ public class MergeService
 		return Math.Max(0.0, (double)unchangedLines / totalLines);
 	}
 
-	private static void ShowDiff(string content1, string content2, string path1, string path2)
+	private const int DiffLineCap = 50;
+
+	private static void ShowDiff(string content1, string content2, string path1, string path2, DiffStyle style)
+	{
+		AnsiConsole.MarkupLine($"[dim]--- {Path.GetFileName(path1).EscapeMarkup()}[/]");
+		AnsiConsole.MarkupLine($"[dim]+++ {Path.GetFileName(path2).EscapeMarkup()}[/]");
+
+		switch (style)
+		{
+			case DiffStyle.Git:
+				ShowUnifiedDiff(content1, content2);
+				break;
+			case DiffStyle.SideBySide:
+			default:
+				ShowSideBySideDiff(content1, content2);
+				break;
+		}
+
+		AnsiConsole.WriteLine();
+	}
+
+	private static void ShowSideBySideDiff(string content1, string content2)
 	{
 		SideBySideDiffBuilder diffBuilder = new(new Differ());
 		SideBySideDiffModel diff = diffBuilder.BuildDiffModel(content1, content2);
 
-		AnsiConsole.MarkupLine($"[dim]--- {Path.GetFileName(path1).EscapeMarkup()}[/]");
-		AnsiConsole.MarkupLine($"[dim]+++ {Path.GetFileName(path2).EscapeMarkup()}[/]");
-
-		int maxLines = Math.Min(50, Math.Max(diff.OldText.Lines.Count, diff.NewText.Lines.Count));
+		int total = Math.Max(diff.OldText.Lines.Count, diff.NewText.Lines.Count);
+		int maxLines = Math.Min(DiffLineCap, total);
 
 		for (int i = 0; i < maxLines; i++)
 		{
@@ -268,12 +300,46 @@ public class MergeService
 			}
 		}
 
-		if (Math.Max(diff.OldText.Lines.Count, diff.NewText.Lines.Count) > maxLines)
+		if (total > maxLines)
 		{
 			AnsiConsole.MarkupLine("[dim]... (truncated)[/]");
 		}
+	}
 
-		AnsiConsole.WriteLine();
+	private static void ShowUnifiedDiff(string content1, string content2)
+	{
+		DiffPaneModel diff = InlineDiffBuilder.Diff(content1, content2);
+
+		int rendered = 0;
+		foreach (DiffPiece line in diff.Lines)
+		{
+			if (rendered >= DiffLineCap)
+			{
+				AnsiConsole.MarkupLine("[dim]... (truncated)[/]");
+				return;
+			}
+
+			string text = line.Text?.EscapeMarkup() ?? string.Empty;
+			switch (line.Type)
+			{
+				case ChangeType.Inserted:
+					AnsiConsole.MarkupLine($"[green]+{text}[/]");
+					break;
+				case ChangeType.Deleted:
+					AnsiConsole.MarkupLine($"[red]-{text}[/]");
+					break;
+				case ChangeType.Modified:
+					AnsiConsole.MarkupLine($"[red]-{text}[/]");
+					break;
+				case ChangeType.Unchanged:
+					AnsiConsole.MarkupLine($"[dim] {text}[/]");
+					break;
+				case ChangeType.Imaginary:
+					continue;
+			}
+
+			rendered++;
+		}
 	}
 
 	private static string InteractiveMerge(string content1, string content2)

--- a/KtsuTools.Repo/RepoService.cs
+++ b/KtsuTools.Repo/RepoService.cs
@@ -88,7 +88,6 @@ public class RepoService(IGitService gitService, IProcessService processService)
 	/// </summary>
 	public async Task<int> BuildAndTestAsync(AbsoluteDirectoryPath path, bool parallel = false, CancellationToken ct = default)
 	{
-		_ = parallel;
 		Ensure.NotNull(path);
 
 		string fullPath = path.ToString();
@@ -102,7 +101,8 @@ public class RepoService(IGitService gitService, IProcessService processService)
 
 		AnsiConsole.MarkupLine($"[blue]Found {solutionFiles.Count} solution(s).[/]");
 
-		int failCount = 0;
+		ConcurrentBag<string> failedSolutions = [];
+		object consoleLock = new();
 
 		await AnsiConsole.Progress()
 			.AutoClear(false)
@@ -111,48 +111,95 @@ public class RepoService(IGitService gitService, IProcessService processService)
 			{
 				ProgressTask task = progressContext.AddTask("[green]Building and testing[/]", maxValue: solutionFiles.Count);
 
-				foreach (string sln in solutionFiles)
+				if (parallel)
 				{
-					ct.ThrowIfCancellationRequested();
+					// dotnet build already uses multiple cores internally; half of ProcessorCount keeps us from thrashing.
+					int dop = Math.Max(1, Environment.ProcessorCount / 2);
+					ParallelOptions options = new() { CancellationToken = ct, MaxDegreeOfParallelism = dop };
 
-					string slnDir = Path.GetDirectoryName(sln) ?? fullPath;
-					string slnName = Path.GetFileNameWithoutExtension(sln);
-
-					task.Description = $"[green]Building {slnName.EscapeMarkup()}[/]";
-
-					// Build
-					ProcessResult buildResult = await processService.RunAsync(DotnetCommand, "build --nologo -v q", slnDir, ct).ConfigureAwait(false);
-
-					if (buildResult.ExitCode != 0)
+					await Parallel.ForEachAsync(solutionFiles, options, async (sln, token) =>
 					{
-						AnsiConsole.MarkupLine($"  [red]FAIL[/] {slnName.EscapeMarkup()} - build failed");
-						failCount++;
-						task.Increment(1);
-						continue;
-					}
-
-					// Test
-					ProcessResult testResult = await processService.RunAsync(DotnetCommand, "test --nologo --no-build -v q", slnDir, ct).ConfigureAwait(false);
-
-					if (testResult.ExitCode != 0)
+						await BuildAndTestSolutionAsync(sln, fullPath, task, consoleLock, failedSolutions, token).ConfigureAwait(false);
+					}).ConfigureAwait(false);
+				}
+				else
+				{
+					foreach (string sln in solutionFiles)
 					{
-						AnsiConsole.MarkupLine($"  [yellow]WARN[/] {slnName.EscapeMarkup()} - build OK, tests failed");
-						failCount++;
+						ct.ThrowIfCancellationRequested();
+						await BuildAndTestSolutionAsync(sln, fullPath, task, consoleLock, failedSolutions, ct).ConfigureAwait(false);
 					}
-					else
-					{
-						AnsiConsole.MarkupLine($"  [green]OK[/]   {slnName.EscapeMarkup()}");
-					}
-
-					task.Increment(1);
 				}
 			}).ConfigureAwait(false);
 
-		AnsiConsole.MarkupLine(failCount > 0
-			? $"[yellow]Done. {failCount} solution(s) had failures.[/]"
-			: "[green]Done. All solutions built and tested successfully.[/]");
+		int failCount = failedSolutions.Count;
+
+		if (failCount > 0)
+		{
+			AnsiConsole.MarkupLine($"[yellow]Done. {failCount} solution(s) had failures:[/]");
+			foreach (string name in failedSolutions.OrderBy(s => s, StringComparer.OrdinalIgnoreCase))
+			{
+				AnsiConsole.MarkupLine($"  [red]-[/] {name.EscapeMarkup()}");
+			}
+		}
+		else
+		{
+			AnsiConsole.MarkupLine("[green]Done. All solutions built and tested successfully.[/]");
+		}
 
 		return failCount > 0 ? 1 : 0;
+	}
+
+	private async Task BuildAndTestSolutionAsync(
+		string sln,
+		string fullPath,
+		ProgressTask task,
+		object consoleLock,
+		ConcurrentBag<string> failedSolutions,
+		CancellationToken ct)
+	{
+		string slnDir = Path.GetDirectoryName(sln) ?? fullPath;
+		string slnName = Path.GetFileNameWithoutExtension(sln);
+
+		lock (consoleLock)
+		{
+			task.Description = $"[green]Building {slnName.EscapeMarkup()}[/]";
+		}
+
+		ProcessResult buildResult = await processService.RunAsync(DotnetCommand, "build --nologo -v q", slnDir, ct).ConfigureAwait(false);
+
+		if (buildResult.ExitCode != 0)
+		{
+			lock (consoleLock)
+			{
+				AnsiConsole.MarkupLine($"  [red]FAIL[/] {slnName.EscapeMarkup()} - build failed");
+				task.Increment(1);
+			}
+
+			failedSolutions.Add(slnName);
+			return;
+		}
+
+		ProcessResult testResult = await processService.RunAsync(DotnetCommand, "test --nologo --no-build -v q", slnDir, ct).ConfigureAwait(false);
+
+		lock (consoleLock)
+		{
+			if (testResult.ExitCode != 0)
+			{
+				AnsiConsole.MarkupLine($"  [yellow]WARN[/] {slnName.EscapeMarkup()} - build OK, tests failed");
+			}
+			else
+			{
+				AnsiConsole.MarkupLine($"  [green]OK[/]   {slnName.EscapeMarkup()}");
+			}
+
+			task.Increment(1);
+		}
+
+		if (testResult.ExitCode != 0)
+		{
+			failedSolutions.Add(slnName);
+		}
 	}
 
 	/// <summary>

--- a/KtsuTools.Test/FileDedupeServiceTests.cs
+++ b/KtsuTools.Test/FileDedupeServiceTests.cs
@@ -1,0 +1,115 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace KtsuTools.Test;
+
+using System.IO;
+using System.Linq;
+using ktsu.Semantics.Paths;
+using KtsuTools.FileDedupe;
+
+[TestClass]
+public class FileDedupeServiceTests
+{
+	[TestMethod]
+	public async Task PlanAsyncMissingDirectoryReturnsEmptyPlan()
+	{
+		FileDedupeService service = new();
+		string missing = Path.Combine(Path.GetTempPath(), $"ktsu_dedup_missing_{Guid.NewGuid():N}");
+		AbsoluteDirectoryPath path = AbsoluteDirectoryPath.Create<AbsoluteDirectoryPath>(missing);
+		DedupePlan plan = await service.PlanAsync(path).ConfigureAwait(false);
+		Assert.AreEqual(0, plan.Groups.Count);
+		Assert.AreEqual(0, plan.Removals.Count);
+	}
+
+	[TestMethod]
+	public async Task PlanAsyncGroupsByContentAndPicksShortestFilenameAsKeeper()
+	{
+		string root = Path.Combine(Path.GetTempPath(), $"ktsu_dedup_{Guid.NewGuid():N}");
+		Directory.CreateDirectory(root);
+		try
+		{
+			string shortName = Path.Combine(root, "a.txt");
+			string mediumName = Path.Combine(root, "aaa.txt");
+			string longName = Path.Combine(root, "aaaaa.txt");
+			string unique = Path.Combine(root, "b.txt");
+
+			await File.WriteAllTextAsync(shortName, "same").ConfigureAwait(false);
+			await File.WriteAllTextAsync(mediumName, "same").ConfigureAwait(false);
+			await File.WriteAllTextAsync(longName, "same").ConfigureAwait(false);
+			await File.WriteAllTextAsync(unique, "different").ConfigureAwait(false);
+
+			FileDedupeService service = new();
+			AbsoluteDirectoryPath path = AbsoluteDirectoryPath.Create<AbsoluteDirectoryPath>(root);
+			DedupePlan plan = await service.PlanAsync(path).ConfigureAwait(false);
+
+			Assert.AreEqual(1, plan.Groups.Count, "Only the three duplicates form a group; the unique file is excluded.");
+			DuplicateGroup group = plan.Groups[0];
+			Assert.AreEqual(3, group.Files.Count);
+			Assert.AreEqual(shortName, plan.Keepers.Single(), "Keeper is the shortest filename.");
+			CollectionAssert.AreEquivalent(new[] { mediumName, longName }, plan.Removals.ToArray());
+		}
+		finally
+		{
+			Directory.Delete(root, recursive: true);
+		}
+	}
+
+	[TestMethod]
+	public async Task PlanAsyncIgnoresSingletonGroups()
+	{
+		string root = Path.Combine(Path.GetTempPath(), $"ktsu_dedup_solo_{Guid.NewGuid():N}");
+		Directory.CreateDirectory(root);
+		try
+		{
+			await File.WriteAllTextAsync(Path.Combine(root, "x.txt"), "x").ConfigureAwait(false);
+			await File.WriteAllTextAsync(Path.Combine(root, "y.txt"), "y").ConfigureAwait(false);
+
+			FileDedupeService service = new();
+			AbsoluteDirectoryPath path = AbsoluteDirectoryPath.Create<AbsoluteDirectoryPath>(root);
+			DedupePlan plan = await service.PlanAsync(path).ConfigureAwait(false);
+
+			Assert.AreEqual(0, plan.Groups.Count);
+			Assert.AreEqual(0, plan.WastedBytes);
+		}
+		finally
+		{
+			Directory.Delete(root, recursive: true);
+		}
+	}
+
+	[TestMethod]
+	public async Task DeleteRedundantRemovesAllButTheKeeper()
+	{
+		string root = Path.Combine(Path.GetTempPath(), $"ktsu_dedup_del_{Guid.NewGuid():N}");
+		Directory.CreateDirectory(root);
+		try
+		{
+			string keeper = Path.Combine(root, "a.txt");
+			string dup1 = Path.Combine(root, "aaa.txt");
+			string dup2 = Path.Combine(root, "aaaaa.txt");
+			await File.WriteAllTextAsync(keeper, "same").ConfigureAwait(false);
+			await File.WriteAllTextAsync(dup1, "same").ConfigureAwait(false);
+			await File.WriteAllTextAsync(dup2, "same").ConfigureAwait(false);
+
+			FileDedupeService service = new();
+			AbsoluteDirectoryPath path = AbsoluteDirectoryPath.Create<AbsoluteDirectoryPath>(root);
+			DedupePlan plan = await service.PlanAsync(path).ConfigureAwait(false);
+
+			int deleted = service.DeleteRedundant(plan);
+
+			Assert.AreEqual(2, deleted);
+			Assert.IsTrue(File.Exists(keeper));
+			Assert.IsFalse(File.Exists(dup1));
+			Assert.IsFalse(File.Exists(dup2));
+		}
+		finally
+		{
+			if (Directory.Exists(root))
+			{
+				Directory.Delete(root, recursive: true);
+			}
+		}
+	}
+}

--- a/KtsuTools.Test/KtsuTools.Test.csproj
+++ b/KtsuTools.Test/KtsuTools.Test.csproj
@@ -26,6 +26,7 @@
     <ProjectReference Include="..\KtsuTools.MemFrag\KtsuTools.MemFrag.csproj" />
     <ProjectReference Include="..\KtsuTools.Machine\KtsuTools.Machine.csproj" />
     <ProjectReference Include="..\KtsuTools.Project\KtsuTools.Project.csproj" />
+    <ProjectReference Include="..\KtsuTools.FileDedupe\KtsuTools.FileDedupe.csproj" />
     <ProjectReference Include="..\KtsuTools.FileExplorer\KtsuTools.FileExplorer.csproj" />
     <ProjectReference Include="..\KtsuTools.SvnMigrate\KtsuTools.SvnMigrate.csproj" />
     <ProjectReference Include="..\KtsuTools.Sync\KtsuTools.Sync.csproj" />

--- a/KtsuTools.Test/MergeServiceTests.cs
+++ b/KtsuTools.Test/MergeServiceTests.cs
@@ -62,4 +62,38 @@ public class MergeServiceTests
 			Directory.Delete(root, recursive: true);
 		}
 	}
+
+	[TestMethod]
+	public void DiffStyleParserAcceptsCanonicalNames()
+	{
+		Assert.IsTrue(DiffStyleParser.TryParse("side-by-side", out DiffStyle side));
+		Assert.AreEqual(DiffStyle.SideBySide, side);
+
+		Assert.IsTrue(DiffStyleParser.TryParse("git", out DiffStyle git));
+		Assert.AreEqual(DiffStyle.Git, git);
+	}
+
+	[TestMethod]
+	public void DiffStyleParserDefaultsForNullOrEmpty()
+	{
+		Assert.IsTrue(DiffStyleParser.TryParse(null, out DiffStyle a));
+		Assert.AreEqual(DiffStyle.SideBySide, a);
+
+		Assert.IsTrue(DiffStyleParser.TryParse("  ", out DiffStyle b));
+		Assert.AreEqual(DiffStyle.SideBySide, b);
+	}
+
+	[TestMethod]
+	public void DiffStyleParserRejectsUnknownValues()
+	{
+		Assert.IsFalse(DiffStyleParser.TryParse("rainbow", out DiffStyle _));
+		Assert.IsFalse(DiffStyleParser.TryParse("ColoredDeluxe", out DiffStyle _));
+	}
+
+	[TestMethod]
+	public void DiffStyleParserRoundTripsCanonicalForm()
+	{
+		Assert.AreEqual("side-by-side", DiffStyleParser.ToCanonicalString(DiffStyle.SideBySide));
+		Assert.AreEqual("git", DiffStyleParser.ToCanonicalString(DiffStyle.Git));
+	}
 }

--- a/KtsuTools.Test/RepoServiceTests.cs
+++ b/KtsuTools.Test/RepoServiceTests.cs
@@ -4,7 +4,11 @@
 
 namespace KtsuTools.Test;
 
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using ktsu.Semantics.Paths;
 using KtsuTools.Core.Services.Git;
 using KtsuTools.Core.Services.Process;
@@ -48,6 +52,95 @@ public class RepoServiceTests
 		finally
 		{
 			Directory.Delete(root, recursive: true);
+		}
+	}
+
+	[TestMethod]
+	public async Task BuildAndTestAsyncParallelAggregatesExitCodes()
+	{
+		string root = Path.Combine(Path.GetTempPath(), $"ktsu_par_{Guid.NewGuid():N}");
+		Directory.CreateDirectory(root);
+		try
+		{
+			// Two top-level solutions in separate subdirs.
+			string slnAPath = Path.Combine(root, "a", "A.sln");
+			string slnBPath = Path.Combine(root, "b", "B.sln");
+			Directory.CreateDirectory(Path.GetDirectoryName(slnAPath)!);
+			Directory.CreateDirectory(Path.GetDirectoryName(slnBPath)!);
+			await File.WriteAllTextAsync(slnAPath, string.Empty).ConfigureAwait(false);
+			await File.WriteAllTextAsync(slnBPath, string.Empty).ConfigureAwait(false);
+
+			DelayedFakeProcessService fake = new(delayMs: 50, failBuildInDirNamed: "b");
+			RepoService service = new(new Mock<IGitService>().Object, fake);
+			AbsoluteDirectoryPath rootPath = AbsoluteDirectoryPath.Create<AbsoluteDirectoryPath>(root);
+
+			int exit = await service.BuildAndTestAsync(rootPath, parallel: true).ConfigureAwait(false);
+
+			Assert.AreEqual(1, exit, "Aggregated exit code should be non-zero when any solution fails.");
+		}
+		finally
+		{
+			Directory.Delete(root, recursive: true);
+		}
+	}
+
+	[TestMethod]
+	public async Task BuildAndTestAsyncParallelIsFasterThanSequential()
+	{
+		string root = Path.Combine(Path.GetTempPath(), $"ktsu_parspeed_{Guid.NewGuid():N}");
+		Directory.CreateDirectory(root);
+		try
+		{
+			for (int i = 0; i < 4; i++)
+			{
+				string dir = Path.Combine(root, $"s{i}");
+				Directory.CreateDirectory(dir);
+				await File.WriteAllTextAsync(Path.Combine(dir, $"S{i}.sln"), string.Empty).ConfigureAwait(false);
+			}
+
+			AbsoluteDirectoryPath rootPath = AbsoluteDirectoryPath.Create<AbsoluteDirectoryPath>(root);
+
+			DelayedFakeProcessService fakeSeq = new(delayMs: 120);
+			RepoService seqService = new(new Mock<IGitService>().Object, fakeSeq);
+			Stopwatch swSeq = Stopwatch.StartNew();
+			await seqService.BuildAndTestAsync(rootPath, parallel: false).ConfigureAwait(false);
+			swSeq.Stop();
+
+			DelayedFakeProcessService fakePar = new(delayMs: 120);
+			RepoService parService = new(new Mock<IGitService>().Object, fakePar);
+			Stopwatch swPar = Stopwatch.StartNew();
+			await parService.BuildAndTestAsync(rootPath, parallel: true).ConfigureAwait(false);
+			swPar.Stop();
+
+			Assert.IsTrue(
+				swPar.ElapsedMilliseconds < swSeq.ElapsedMilliseconds,
+				$"Parallel ({swPar.ElapsedMilliseconds} ms) should be faster than sequential ({swSeq.ElapsedMilliseconds} ms).");
+		}
+		finally
+		{
+			Directory.Delete(root, recursive: true);
+		}
+	}
+
+	private sealed class DelayedFakeProcessService(int delayMs, string? failBuildInDirNamed = null) : IProcessService
+	{
+		public Task<ProcessResult> RunAsync(string command, string arguments, string? workingDirectory = null, CancellationToken ct = default) =>
+			RunAsync(command, arguments, workingDirectory, null, ct);
+
+		public async Task<ProcessResult> RunAsync(string command, string arguments, string? workingDirectory, IDictionary<string, string>? environmentVariables, CancellationToken ct = default)
+		{
+			await Task.Delay(delayMs, ct).ConfigureAwait(false);
+
+			int exit = 0;
+			if (failBuildInDirNamed is not null &&
+				arguments.StartsWith("build", StringComparison.Ordinal) &&
+				workingDirectory is not null &&
+				string.Equals(Path.GetFileName(workingDirectory), failBuildInDirNamed, StringComparison.OrdinalIgnoreCase))
+			{
+				exit = 1;
+			}
+
+			return new ProcessResult(exit, [], []);
 		}
 	}
 }

--- a/KtsuTools.slnx
+++ b/KtsuTools.slnx
@@ -2,6 +2,7 @@
   <Project Path="KtsuTools.BuildMonitor/KtsuTools.BuildMonitor.csproj" />
   <Project Path="KtsuTools.CodeGen/KtsuTools.CodeGen.csproj" />
   <Project Path="KtsuTools.Core/KtsuTools.Core.csproj" />
+  <Project Path="KtsuTools.FileDedupe/KtsuTools.FileDedupe.csproj" />
   <Project Path="KtsuTools.FileExplorer/KtsuTools.FileExplorer.csproj" />
   <Project Path="KtsuTools.Image/KtsuTools.Image.csproj" />
   <Project Path="KtsuTools.Machine/KtsuTools.Machine.csproj" />

--- a/KtsuTools/Commands/DedupDeleteCommand.cs
+++ b/KtsuTools/Commands/DedupDeleteCommand.cs
@@ -1,0 +1,63 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace KtsuTools.Commands;
+
+using System.ComponentModel;
+using System.IO;
+using ktsu.Semantics.Paths;
+using KtsuTools.Core.UI;
+using KtsuTools.FileDedupe;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+public sealed class DedupDeleteCommand(FileDedupeService dedupeService) : AsyncCommand<DedupDeleteCommand.Settings>
+{
+	private readonly FileDedupeService dedupeService = dedupeService;
+
+	public sealed class Settings : CommandSettings
+	{
+		[CommandOption("-p|--path <PATH>")]
+		[Description("Directory to scan for duplicates")]
+		public required string Path { get; init; }
+
+		[CommandOption("-y|--yes")]
+		[Description("Skip confirmation prompt")]
+		[DefaultValue(false)]
+		public bool AssumeYes { get; init; }
+	}
+
+	public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
+	{
+		Ensure.NotNull(settings);
+		using CtrlCScope scope = new();
+
+		AbsoluteDirectoryPath path = AbsoluteDirectoryPath.Create<AbsoluteDirectoryPath>(Path.GetFullPath(settings.Path));
+		AnsiConsole.MarkupLine($"[bold]Dedup delete[/] - {path.ToString().EscapeMarkup()}");
+
+		DedupePlan plan = await dedupeService.PlanAsync(path, scope.Token).ConfigureAwait(false);
+
+		if (plan.Removals.Count == 0)
+		{
+			AnsiConsole.MarkupLine("[green]Nothing to delete.[/]");
+			return 0;
+		}
+
+		AnsiConsole.MarkupLine($"[yellow]Will delete {plan.Removals.Count} file(s); shortest-filename winners are kept.[/]");
+
+		if (!settings.AssumeYes)
+		{
+			bool ok = AnsiConsole.Confirm("Proceed with deletion?", defaultValue: false);
+			if (!ok)
+			{
+				AnsiConsole.MarkupLine("[dim]Cancelled.[/]");
+				return 0;
+			}
+		}
+
+		int deleted = dedupeService.DeleteRedundant(plan);
+		AnsiConsole.MarkupLine($"[green]Deleted {deleted} file(s).[/]");
+		return 0;
+	}
+}

--- a/KtsuTools/Commands/DedupDryRunCommand.cs
+++ b/KtsuTools/Commands/DedupDryRunCommand.cs
@@ -1,0 +1,56 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace KtsuTools.Commands;
+
+using System.ComponentModel;
+using System.IO;
+using ktsu.Semantics.Paths;
+using KtsuTools.Core.UI;
+using KtsuTools.FileDedupe;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+public sealed class DedupDryRunCommand(FileDedupeService dedupeService) : AsyncCommand<DedupDryRunCommand.Settings>
+{
+	private readonly FileDedupeService dedupeService = dedupeService;
+
+	public sealed class Settings : CommandSettings
+	{
+		[CommandOption("-p|--path <PATH>")]
+		[Description("Directory to scan for duplicates")]
+		public required string Path { get; init; }
+	}
+
+	public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
+	{
+		Ensure.NotNull(settings);
+		using CtrlCScope scope = new();
+
+		AbsoluteDirectoryPath path = AbsoluteDirectoryPath.Create<AbsoluteDirectoryPath>(Path.GetFullPath(settings.Path));
+		AnsiConsole.MarkupLine($"[bold]Dedup dry-run[/] - {path.ToString().EscapeMarkup()}");
+
+		DedupePlan plan = await dedupeService.PlanAsync(path, scope.Token).ConfigureAwait(false);
+
+		if (plan.Removals.Count == 0)
+		{
+			AnsiConsole.MarkupLine("[green]Nothing to delete.[/]");
+			return 0;
+		}
+
+		AnsiConsole.MarkupLine("[yellow]Would delete (shortest-filename winners are kept):[/]");
+		foreach (string keeper in plan.Keepers)
+		{
+			AnsiConsole.MarkupLine($"  [green]keep[/] {keeper.EscapeMarkup()}");
+		}
+
+		foreach (string removal in plan.Removals)
+		{
+			AnsiConsole.MarkupLine($"  [red]drop[/] {removal.EscapeMarkup()}");
+		}
+
+		AnsiConsole.MarkupLine($"[blue]{plan.Removals.Count} file(s), {plan.WastedBytes} byte(s) would be reclaimed.[/]");
+		return 0;
+	}
+}

--- a/KtsuTools/Commands/DedupScanCommand.cs
+++ b/KtsuTools/Commands/DedupScanCommand.cs
@@ -1,0 +1,54 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace KtsuTools.Commands;
+
+using System.ComponentModel;
+using System.IO;
+using ktsu.Semantics.Paths;
+using KtsuTools.Core.UI;
+using KtsuTools.FileDedupe;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+public sealed class DedupScanCommand(FileDedupeService dedupeService) : AsyncCommand<DedupScanCommand.Settings>
+{
+	private readonly FileDedupeService dedupeService = dedupeService;
+
+	public sealed class Settings : CommandSettings
+	{
+		[CommandOption("-p|--path <PATH>")]
+		[Description("Directory to scan for duplicates")]
+		public required string Path { get; init; }
+	}
+
+	public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
+	{
+		Ensure.NotNull(settings);
+		using CtrlCScope scope = new();
+
+		AbsoluteDirectoryPath path = AbsoluteDirectoryPath.Create<AbsoluteDirectoryPath>(Path.GetFullPath(settings.Path));
+		AnsiConsole.MarkupLine($"[bold]Dedup scan[/] - {path.ToString().EscapeMarkup()}");
+
+		DedupePlan plan = await dedupeService.PlanAsync(path, scope.Token).ConfigureAwait(false);
+
+		if (plan.Groups.Count == 0)
+		{
+			AnsiConsole.MarkupLine("[green]No duplicate groups found.[/]");
+			return 0;
+		}
+
+		foreach (DuplicateGroup group in plan.Groups)
+		{
+			AnsiConsole.MarkupLine($"[yellow]{group.Files.Count}[/] files, {group.FileSize} bytes each ({group.Hash[..12]})");
+			foreach (string file in group.Files)
+			{
+				AnsiConsole.MarkupLine($"  {file.EscapeMarkup()}");
+			}
+		}
+
+		AnsiConsole.MarkupLine($"[blue]{plan.Groups.Count} duplicate group(s), {plan.WastedBytes} wasted byte(s).[/]");
+		return 0;
+	}
+}

--- a/KtsuTools/Commands/DedupStatsCommand.cs
+++ b/KtsuTools/Commands/DedupStatsCommand.cs
@@ -1,0 +1,62 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace KtsuTools.Commands;
+
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using ktsu.Semantics.Paths;
+using KtsuTools.Core.UI;
+using KtsuTools.FileDedupe;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+public sealed class DedupStatsCommand(FileDedupeService dedupeService) : AsyncCommand<DedupStatsCommand.Settings>
+{
+	private readonly FileDedupeService dedupeService = dedupeService;
+
+	public sealed class Settings : CommandSettings
+	{
+		[CommandOption("-p|--path <PATH>")]
+		[Description("Directory to summarize")]
+		public required string Path { get; init; }
+	}
+
+	public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
+	{
+		Ensure.NotNull(settings);
+		using CtrlCScope scope = new();
+
+		AbsoluteDirectoryPath path = AbsoluteDirectoryPath.Create<AbsoluteDirectoryPath>(Path.GetFullPath(settings.Path));
+		AnsiConsole.MarkupLine($"[bold]Dedup stats[/] - {path.ToString().EscapeMarkup()}");
+
+		int filesScanned = Directory.Exists(path.ToString())
+			? Directory.GetFiles(path.ToString(), "*", SearchOption.AllDirectories).Length
+			: 0;
+
+		DedupePlan plan = await dedupeService.PlanAsync(path, scope.Token).ConfigureAwait(false);
+		DedupeStats stats = dedupeService.Summarize(plan, filesScanned);
+
+		Table table = new();
+		table.AddColumn("Metric");
+		table.AddColumn("Value");
+		table.AddRow("Files scanned", stats.FilesScanned.ToString());
+		table.AddRow("Duplicate groups", stats.DuplicateGroups.ToString());
+		table.AddRow("Redundant files", stats.RedundantFiles.ToString());
+		table.AddRow("Wasted bytes", stats.WastedBytes.ToString());
+		AnsiConsole.Write(table);
+
+		if (stats.CountByExtension.Count > 0)
+		{
+			AnsiConsole.MarkupLine("[bold]Duplicate files by extension:[/]");
+			foreach ((string ext, int count) in stats.CountByExtension.OrderByDescending(kv => kv.Value))
+			{
+				AnsiConsole.MarkupLine($"  {ext.EscapeMarkup()}: {count}");
+			}
+		}
+
+		return 0;
+	}
+}

--- a/KtsuTools/Commands/MergeBatchSaveCommand.cs
+++ b/KtsuTools/Commands/MergeBatchSaveCommand.cs
@@ -29,8 +29,18 @@ public sealed class MergeBatchSaveCommand(MergeBatchService batchService) : Asyn
 		public required string Filename { get; init; }
 
 		[CommandOption("--diff-style <STYLE>")]
-		[Description("Diff style to use when running this batch (reserved for future use)")]
+		[Description("Diff style to apply when this batch is run: side-by-side (default) or git")]
 		public string? DiffStyle { get; init; }
+
+		public override ValidationResult Validate()
+		{
+			if (DiffStyle is not null && !DiffStyleParser.TryParse(DiffStyle, out _))
+			{
+				return ValidationResult.Error($"Unknown --diff-style '{DiffStyle}'. Expected 'side-by-side' or 'git'.");
+			}
+
+			return ValidationResult.Success();
+		}
 	}
 
 	public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
@@ -38,11 +48,17 @@ public sealed class MergeBatchSaveCommand(MergeBatchService batchService) : Asyn
 		Ensure.NotNull(settings);
 		using CtrlCScope scope = new();
 
+		string? canonicalDiffStyle = null;
+		if (settings.DiffStyle is not null && DiffStyleParser.TryParse(settings.DiffStyle, out DiffStyle parsed))
+		{
+			canonicalDiffStyle = DiffStyleParser.ToCanonicalString(parsed);
+		}
+
 		MergeBatchEntry entry = new()
 		{
 			Directory = settings.Directory,
 			Filename = settings.Filename,
-			DiffStyle = settings.DiffStyle,
+			DiffStyle = canonicalDiffStyle,
 		};
 
 		await batchService.SaveAsync(settings.Name, entry, scope.Token).ConfigureAwait(false);

--- a/KtsuTools/Commands/MergeCommand.cs
+++ b/KtsuTools/Commands/MergeCommand.cs
@@ -31,6 +31,11 @@ public sealed class MergeCommand(MergeService mergeService, MergeBatchService ba
 		[Description("Run a saved batch by name (use 'merge-batch save' to create one)")]
 		public string? BatchName { get; init; }
 
+		[CommandOption("--diff-style <STYLE>")]
+		[Description("How to render conflict diffs: side-by-side (default) or git")]
+		[DefaultValue("side-by-side")]
+		public string DiffStyle { get; init; } = "side-by-side";
+
 		public override ValidationResult Validate()
 		{
 			bool hasDirectory = !string.IsNullOrWhiteSpace(Directory);
@@ -54,6 +59,11 @@ public sealed class MergeCommand(MergeService mergeService, MergeBatchService ba
 				return ValidationResult.Error("Provide either <directory> <filename> or --batch <name>.");
 			}
 
+			if (!DiffStyleParser.TryParse(DiffStyle, out _))
+			{
+				return ValidationResult.Error($"Unknown --diff-style '{DiffStyle}'. Expected 'side-by-side' or 'git'.");
+			}
+
 			return ValidationResult.Success();
 		}
 	}
@@ -65,6 +75,7 @@ public sealed class MergeCommand(MergeService mergeService, MergeBatchService ba
 
 		string directoryArg;
 		string filenameArg;
+		DiffStyle diffStyle;
 
 		if (!string.IsNullOrWhiteSpace(settings.BatchName))
 		{
@@ -77,18 +88,28 @@ public sealed class MergeCommand(MergeService mergeService, MergeBatchService ba
 
 			directoryArg = entry.Directory;
 			filenameArg = entry.Filename;
+
+			// Batch's saved DiffStyle wins when present; otherwise fall back to the flag (or its default).
+			if (!DiffStyleParser.TryParse(entry.DiffStyle ?? settings.DiffStyle, out diffStyle))
+			{
+				AnsiConsole.MarkupLine($"[red]Error: batch '{settings.BatchName.EscapeMarkup()}' has unknown DiffStyle '{(entry.DiffStyle ?? string.Empty).EscapeMarkup()}'.[/]");
+				return 1;
+			}
+
 			AnsiConsole.MarkupLine($"[dim]Running batch '{settings.BatchName.EscapeMarkup()}': {directoryArg.EscapeMarkup()} / {filenameArg.EscapeMarkup()}[/]");
 		}
 		else
 		{
 			directoryArg = settings.Directory!;
 			filenameArg = settings.Filename!;
+			DiffStyleParser.TryParse(settings.DiffStyle, out diffStyle);
 		}
 
 		AbsoluteDirectoryPath directory = AbsoluteDirectoryPath.Create<AbsoluteDirectoryPath>(Path.GetFullPath(directoryArg));
 		return await mergeService.RunMergeAsync(
 			directory,
 			filenameArg,
+			diffStyle,
 			scope.Token).ConfigureAwait(false);
 	}
 }

--- a/KtsuTools/KtsuTools.csproj
+++ b/KtsuTools/KtsuTools.csproj
@@ -25,6 +25,7 @@
     <ProjectReference Include="..\KtsuTools.MemFrag\KtsuTools.MemFrag.csproj" />
     <ProjectReference Include="..\KtsuTools.Machine\KtsuTools.Machine.csproj" />
     <ProjectReference Include="..\KtsuTools.Project\KtsuTools.Project.csproj" />
+    <ProjectReference Include="..\KtsuTools.FileDedupe\KtsuTools.FileDedupe.csproj" />
     <ProjectReference Include="..\KtsuTools.FileExplorer\KtsuTools.FileExplorer.csproj" />
     <ProjectReference Include="..\KtsuTools.SvnMigrate\KtsuTools.SvnMigrate.csproj" />
     <ProjectReference Include="..\KtsuTools.Sync\KtsuTools.Sync.csproj" />

--- a/KtsuTools/Program.cs
+++ b/KtsuTools/Program.cs
@@ -8,6 +8,7 @@ using KtsuTools.BuildMonitor;
 using KtsuTools.CodeGen;
 using KtsuTools.Commands;
 using KtsuTools.Core.Services;
+using KtsuTools.FileDedupe;
 using KtsuTools.FileExplorer;
 using KtsuTools.Infrastructure;
 using KtsuTools.Machine;
@@ -43,6 +44,7 @@ internal static class Program
 		services.AddSingleton<MachineMonitorService>();
 		services.AddSingleton<ProjectService>();
 		services.AddSingleton<SyncService>();
+		services.AddSingleton<FileDedupeService>();
 
 		TypeRegistrar registrar = new(services);
 		CommandApp app = new(registrar);
@@ -169,6 +171,27 @@ internal static class Program
 			config.AddCommand<SyncCommand>("sync")
 				.WithDescription("Synchronize file contents across repositories")
 				.WithExample("sync", "--path", "c:/dev/ktsu-dev", "--filename", ".editorconfig");
+
+			config.AddBranch("dedup", dedup =>
+			{
+				dedup.SetDescription("Find and remove duplicate files (shortest filename wins)");
+
+				dedup.AddCommand<DedupScanCommand>("scan")
+					.WithDescription("Display duplicate-content file groups")
+					.WithExample("dedup", "scan", "--path", ".");
+
+				dedup.AddCommand<DedupDryRunCommand>("dry-run")
+					.WithDescription("Preview which files would be deleted")
+					.WithExample("dedup", "dry-run", "--path", ".");
+
+				dedup.AddCommand<DedupDeleteCommand>("dedupe")
+					.WithDescription("Delete redundant duplicate files (prompts for confirmation)")
+					.WithExample("dedup", "dedupe", "--path", ".");
+
+				dedup.AddCommand<DedupStatsCommand>("stats")
+					.WithDescription("Show duplicate totals, wasted bytes, and breakdown by extension")
+					.WithExample("dedup", "stats", "--path", ".");
+			});
 		});
 
 		return app.Run(args);


### PR DESCRIPTION
Three independent, non-conflicting issues from the open backlog, each in its own commit.

## Summary

- **#35 — `repo build --parallel` is now real.** `RepoService.BuildAndTestAsync` was discarding the flag (`_ = parallel;`). It now uses `Parallel.ForEachAsync` with `MaxDegreeOfParallelism = ProcessorCount/2` (dotnet build is already multithreaded — going wider thrashes), serialises Spectre console writes behind a lock, and aggregates failed solution names into the summary instead of just emitting a count.
- **#37 — `ktsu merge --diff-style {side-by-side|git}`.** Adds a `DiffStyle` enum plumbed through `MergeService.RunMergeAsync`. The git/unified renderer uses DiffPlex's `InlineDiffBuilder`; the existing side-by-side renderer stays the default. A shared `DiffStyleParser` handles the string↔enum mapping for the flag, the `merge-batch save --diff-style` flag, and the persisted batch JSON. Unknown values are rejected at the Spectre validation layer.
- **#7 — `ktsu dedup` branch.** New `KtsuTools.FileDedupe` project plus four subcommands (`scan`, `dry-run`, `dedupe`, `stats`). SHA256-based parallel scan; "shortest filename wins" tie-breaker; `dedupe` prompts y/N by default (`-y/--yes` to skip).

## Test plan

- [ ] CI build green on windows-latest (local Linux env can't restore the existing `ktsu.AppDataStorage` ↔ `ktsu.Semantics.Paths` version pin — pre-existing on `main`)
- [ ] `RepoServiceTests.BuildAndTestAsyncParallelAggregatesExitCodes` passes
- [ ] `RepoServiceTests.BuildAndTestAsyncParallelIsFasterThanSequential` passes
- [ ] `MergeServiceTests` diff-style parser tests pass
- [ ] `FileDedupeServiceTests` (4 tests) pass
- [ ] Manually run `ktools dedup scan --path <dir-with-dupes>` and confirm the shortest-name file is the keeper

Closes #7, #35, #37.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AApUYMsMpDonf4EcBjTHq2)_